### PR TITLE
Ensure CLEF files are considered more recent than JSON files when upg…

### DIFF
--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>5.1.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <Copyright>Copyright © Serilog Contributors</Copyright>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;net4.5;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard1.1;netstandard1.3;netstandard2.0;net4.5;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Serilog</RootNamespace>

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSet.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSet.cs
@@ -47,7 +47,7 @@ namespace Serilog.Sinks.Seq.Durable
             // The extension cannot be matched here because it may be either "json" (raw format) or "clef" (compact).
             _candidateSearchPath = Path.GetFileName(bufferBaseFilename) + "-*.*";
             
-            _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>\\d{8})(?<sequence>_[0-9]{3,}){0,1}\\.(json|clef)$");
+            _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>\\d{8})(?<sequence>_[0-9]{3,}){0,1}\\.(?<ext>json|clef)$");
         }
 
         public BookmarkFile OpenBookmarkFile()
@@ -61,6 +61,7 @@ namespace Serilog.Sinks.Seq.Durable
                 .Select(n => new KeyValuePair<string, Match>(n, _filenameMatcher.Match(Path.GetFileName(n))))
                 .Where(nm => nm.Value.Success)
                 .OrderBy(nm => nm.Value.Groups["date"].Value, StringComparer.OrdinalIgnoreCase)
+                .ThenByDescending(nm => nm.Value.Groups["ext"].Value)
                 .ThenBy(nm => int.Parse("0" + nm.Value.Groups["sequence"].Value.Replace("_", "")))
                 .Select(nm => nm.Key)
                 .ToArray();

--- a/test/Serilog.Sinks.Seq.Tests/Durable/FileSetTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Durable/FileSetTests.cs
@@ -15,7 +15,18 @@ namespace Serilog.Sinks.Seq.Tests.Durable
             const string? fakeContent = "{}";
 
             // Matching
-            var shouldMatch = new[] {bbf + "-20180101.json", bbf + "-20180102.json", bbf + "-20180102_001.json"};
+            var shouldMatch = new[]
+            {
+                bbf + "-20180101.json", 
+                bbf + "-20180102.json",
+                bbf + "-20180102_001.json",
+                bbf + "-20180103.json",
+                bbf + "-20180103.clef",
+                bbf + "-20180104.clef",
+                bbf + "-20180104_001.clef",
+                bbf + "-20180104_002.clef",
+                bbf + "-20180105.clef"
+            };
             foreach (var fn in shouldMatch)
                 System.IO.File.WriteAllText(fn, fakeContent);
 
@@ -31,7 +42,7 @@ namespace Serilog.Sinks.Seq.Tests.Durable
             var fileSet = new FileSet(bbf);
             var files = fileSet.GetBufferFiles();
                 
-            Assert.Equal(3, files.Length);
+            Assert.Equal(9, files.Length);
             Assert.Equal(shouldMatch, files);
         }
     }


### PR DESCRIPTION
…rading to the newer on-disk durable format.

Otherwise, after upgrading from an earlier version of the sink, durable shipping will skip newly-buffered events until the date changes.