### PR TITLE
Add IAsyncDisposable support to DurableSeqSink; bump dependency versions

### DIFF
--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Serilog sink that writes to the Seq log server over HTTP/HTTPS.</Description>
-    <VersionPrefix>5.1.2</VersionPrefix>
+    <VersionPrefix>5.2.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <Copyright>Copyright © Serilog Contributors</Copyright>
     <TargetFrameworks>net5.0;netstandard1.1;netstandard1.3;netstandard2.0;net4.5;netcoreapp3.1</TargetFrameworks>
@@ -32,11 +32,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;WRITE_ALL_BYTES_ASYNC</DefineConstants>
+    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;WRITE_ALL_BYTES_ASYNC;ASYNC_DISPOSE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;WRITE_ALL_BYTES_ASYNC</DefineConstants>
+    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;WRITE_ALL_BYTES_ASYNC;ASYNC_DISPOSE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net4.5' ">
@@ -48,8 +48,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
+    <PackageReference Include="Serilog" Version="2.12.0-dev-*" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.0.0-dev-*" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/DurableSeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/DurableSeqSink.cs
@@ -24,6 +24,9 @@ using Serilog.Sinks.Seq.Http;
 namespace Serilog.Sinks.Seq.Durable
 {
     sealed class DurableSeqSink : ILogEventSink, IDisposable
+#if ASYNC_DISPOSE
+        , IAsyncDisposable
+#endif
     {
         readonly HttpLogShipper _shipper;
         readonly Logger _sink;
@@ -73,6 +76,14 @@ namespace Serilog.Sinks.Seq.Durable
             _sink.Dispose();
             _shipper.Dispose();
         }
+        
+#if ASYNC_DISPOSE
+        public async System.Threading.Tasks.ValueTask DisposeAsync()
+        {
+            await _sink.DisposeAsync().ConfigureAwait(false);
+            await _shipper.DisposeAsync().ConfigureAwait(false);
+        }
+#endif
 
         public void Emit(LogEvent logEvent)
         {

--- a/test/Serilog.Sinks.Seq.Tests/Batched/BatchedSeqSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Batched/BatchedSeqSinkTests.cs
@@ -22,7 +22,7 @@ namespace Serilog.Sinks.Seq.Tests.Batched
             
             Assert.True(api.IsDisposed);
         }
-
+        
         [Fact]
         public async Task EventsAreFormattedIntoPayloads()
         {

--- a/test/Serilog.Sinks.Seq.Tests/Serilog.Sinks.Seq.Tests.csproj
+++ b/test/Serilog.Sinks.Seq.Tests/Serilog.Sinks.Seq.Tests.csproj
@@ -9,6 +9,15 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <DefineConstants>$(DefineConstants);ASYNC_DISPOSE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <DefineConstants>$(DefineConstants);ASYNC_DISPOSE</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Content Include="Resources\ThreeBufferedEvents.clef.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
The fix for https://github.com/datalust/serilog-sinks-seq/issues/167 is https://github.com/datalust/serilog-sinks-seq/issues/178; this PR bumps dependency versions so that (when the fix is merged) consumers will get async disposal support on platforms that support it.