### PR TITLE
Limit the default pooled connection lifetime on .NET 5 and greater

### DIFF
--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;WRITE_ALL_BYTES_ASYNC</DefineConstants>
+    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;WRITE_ALL_BYTES_ASYNC;SOCKETS_HTTP_HANDLER_ALWAYS_DEFAULT</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net4.5' ">


### PR DESCRIPTION
See https://github.com/datalust/serilog-sinks-seq/issues/178

.NET 5 is the first platform to always use `SocketsHttpHandler` by default; earlier versions of core and framework may use other handlers depending on configuration.

Clients can still override our default decisions here by supplying a `messageHandler` when configuring the sink.