### PR TITLE
5.2.2 Release

### DIFF
--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.8;net5.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -9,10 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net4.8' ">
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
     
   <ItemGroup>

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -49,7 +49,7 @@
   
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Serilog sink that writes to the Seq log server over HTTP/HTTPS.</Description>
-    <VersionPrefix>5.2.0</VersionPrefix>
+    <VersionPrefix>5.2.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <Copyright>Copyright © Serilog Contributors</Copyright>
     <TargetFrameworks>net5.0;netstandard1.1;netstandard1.3;netstandard2.0;net4.5;netcoreapp3.1</TargetFrameworks>

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Serilog sink that writes to the Seq log server over HTTP/HTTPS.</Description>
-    <VersionPrefix>5.2.1</VersionPrefix>
+    <VersionPrefix>5.2.2</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <Copyright>Copyright © Serilog Contributors</Copyright>
     <TargetFrameworks>net5.0;netstandard1.1;netstandard1.3;netstandard2.0;net4.5;netcoreapp3.1</TargetFrameworks>

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Http/SeqIngestionApiClient.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Http/SeqIngestionApiClient.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Serilog.Events;
@@ -38,6 +39,9 @@ namespace Serilog.Sinks.Seq.Http
             _apiKey = apiKey;
             _httpClient = messageHandler != null
                     ? new HttpClient(messageHandler)
+                    : RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"))
+                    // Can't set PooledConnectionLifetime on this platform
+                    ? new HttpClient()
                     :
 #if SOCKETS_HTTP_HANDLER_ALWAYS_DEFAULT
                     new HttpClient(new SocketsHttpHandler


### PR DESCRIPTION
 * #189 - don't crash on Blazor, where `PooledConnectionLifetime` is not supported (@nblumhardt)
