### PR TITLE
Include a large event body sample when generating oversized event placeholders

### DIFF
--- a/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
@@ -107,9 +107,8 @@ namespace Serilog.Sinks.Seq
         
         static LogEvent CreateOversizeEventPlaceholder(LogEvent logEvent, string jsonLine, long eventBodyLimitBytes)
         {
-            // If the limit is so constrained as to disallow sending 512 bytes + packaging, that's okay - we'll just drop
-            // the placeholder, too.
-            var sample = jsonLine.Substring(0, Math.Min(jsonLine.Length, 512));
+            var sampleLength = GetOversizeEventSampleLength(eventBodyLimitBytes);
+            var sample = jsonLine.Substring(0, Math.Min(jsonLine.Length, (int)sampleLength));
             return new LogEvent(
                 logEvent.Timestamp,
                 LogEventLevel.Error,
@@ -120,6 +119,23 @@ namespace Serilog.Sinks.Seq
                     new LogEventProperty("EventBodyLimitBytes", new ScalarValue(eventBodyLimitBytes)),
                     new LogEventProperty("EventBodySample", new ScalarValue(sample)),
                 });
+        }
+
+        internal static long GetOversizeEventSampleLength(long eventBodyLimitBytes)
+        {
+            // A quick estimate of how much of the original event payload we should send along with the oversized event
+            // placeholder. If the limit is so constrained as to disallow sending the sample, that's okay - we'll
+            // just drop the placeholder, too.
+            
+            // In reality the timestamp and other envelope components won't be anything close to this.
+            const long packagingAllowance = 2048;
+            var byteBudget = eventBodyLimitBytes - packagingAllowance;
+            
+            // Allow for multibyte characters and JSON escape sequences.
+            var withEncoding = byteBudget / 2;
+
+            const long minimumSampleSize = 512;
+            return Math.Max(withEncoding, minimumSampleSize);
         }
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.Seq.Tests
         [InlineData(1000, 512)]
         [InlineData(5000, 1476)]
         [InlineData(10000, 3976)]
-        [InlineData(130048, 3976)]
+        [InlineData(130048, 64000)]
         public void PlaceholderSampleSizeIsComputedFromEventBodyLimitBytes(long eventBodyLimitBytes, long expectedSampleSize)
         {
             var actual = ConstrainedBufferedFormatter.GetOversizeEventSampleLength(eventBodyLimitBytes);

--- a/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
@@ -40,5 +40,19 @@ namespace Serilog.Sinks.Seq.Tests
             Assert.Contains("\"EventBodySample\"", jsonString);
             Assert.Contains("aaaaa", jsonString);
         }
+
+        [Theory]
+        [InlineData(0, 512)]
+        [InlineData(1, 512)]
+        [InlineData(512, 512)]
+        [InlineData(1000, 512)]
+        [InlineData(5000, 1476)]
+        [InlineData(10000, 3976)]
+        [InlineData(130048, 3976)]
+        public void PlaceholderSampleSizeIsComputedFromEventBodyLimitBytes(long eventBodyLimitBytes, long expectedSampleSize)
+        {
+            var actual = ConstrainedBufferedFormatter.GetOversizeEventSampleLength(eventBodyLimitBytes);
+            Assert.Equal(expectedSampleSize, actual);
+        }
     }
 }


### PR DESCRIPTION
See https://github.com/datalust/seq-tickets/discussions/1692#discussioncomment-4193095