### PR TITLE
Avoid using an obsolete source-compatible overload of WriteTo.Sink() …

### DIFF
--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -134,7 +134,7 @@ namespace Serilog
 
             return loggerSinkConfiguration.Conditional(
                 controlledSwitch.IsIncluded,
-                wt => wt.Sink(sink, restrictedToMinimumLevel));
+                wt => wt.Sink(sink, restrictedToMinimumLevel, levelSwitch: null));
         }
 
         /// <summary>


### PR DESCRIPTION
…that may be removed in Serilog 3. See https://github.com/serilog/serilog/issues/1843