### PR TITLE
Update dependencies to ensure trace/span ids are propagated when available

### DIFF
--- a/sample/BlazorWasm/BlazorWasm.csproj
+++ b/sample/BlazorWasm/BlazorWasm.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" PrivateAssets="all" />
-    <PackageReference Include="serilog.extensions.logging" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.11" PrivateAssets="all" />
+    <PackageReference Include="serilog.extensions.logging" Version="7.0.0" />
     <PackageReference Include="serilog.sinks.browserconsole" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -22,10 +22,7 @@ using Serilog.Sinks.PeriodicBatching;
 using Serilog.Sinks.Seq.Batched;
 using Serilog.Sinks.Seq.Audit;
 using Serilog.Sinks.Seq.Http;
-
-#if DURABLE
 using Serilog.Sinks.Seq.Durable;
-#endif
 
 namespace Serilog
 {
@@ -114,7 +111,6 @@ namespace Serilog
             }
             else
             {
-#if DURABLE
                 sink = new DurableSeqSink(
                     serverUrl,
                     bufferBaseFilename,
@@ -126,10 +122,6 @@ namespace Serilog
                     controlledSwitch,
                     messageHandler,
                     retainedInvalidPayloadsLimitBytes);
-#else
-                // We keep the API consistent for easier packaging and to support bait-and-switch.
-                throw new NotSupportedException("Durable log shipping is not supported on this platform.");
-#endif
             }
 
             return loggerSinkConfiguration.Conditional(

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Serilog sink that writes to the Seq log server over HTTP/HTTPS.</Description>
-    <VersionPrefix>5.2.3</VersionPrefix>
-    <Authors>Serilog Contributors</Authors>
+    <Description>A Serilog sink that writes events to Seq using newline-delimited JSON and HTTP/HTTPS.</Description>
+    <VersionPrefix>6.0.0</VersionPrefix>
+    <Authors>Serilog Contributors;Datalust Pty Ltd</Authors>
     <Copyright>Copyright © Serilog Contributors</Copyright>
-    <TargetFrameworks>net5.0;netstandard1.1;netstandard1.3;netstandard2.0;net4.5;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>Serilog</RootNamespace>
@@ -16,59 +16,29 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/serilog/serilog-sinks-seq</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/serilog/serilog-sinks-seq</RepositoryUrl>
+    <RepositoryUrl>https://github.com/datalust/serilog-sinks-seq</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <DefineConstants>$(DefineConstants);WRITE_ALL_BYTES_ASYNC;ASYNC_DISPOSE;SOCKETS_HTTP_HANDLER_ALWAYS_DEFAULT;ARCHITECTURE_WASM</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;WRITE_ALL_BYTES_ASYNC;ASYNC_DISPOSE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;WRITE_ALL_BYTES_ASYNC;ASYNC_DISPOSE;SOCKETS_HTTP_HANDLER_ALWAYS_DEFAULT;ARCHITECTURE_WASM</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net4.5' ">
-    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;HRESULTS</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net4.5' ">
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.1.0-*" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0-*" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.1' ">
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   
 </Project>

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Description>A Serilog sink that writes events to Seq using newline-delimited JSON and HTTP/HTTPS.</Description>
     <VersionPrefix>6.0.0</VersionPrefix>
-    <Authors>Serilog Contributors;Datalust Pty Ltd</Authors>
-    <Copyright>Copyright © Serilog Contributors</Copyright>
+    <Authors>Serilog Contributors;Serilog.Sinks.Seq Contributors;Datalust Pty Ltd</Authors>
+    <Copyright>Copyright © Serilog Contributors, Serilog.Sinks.Seq Contributors, Datalust Pty Ltd.</Copyright>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -19,7 +19,7 @@
     <RepositoryUrl>https://github.com/datalust/serilog-sinks-seq</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Audit/SeqAuditSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Audit/SeqAuditSink.cs
@@ -21,40 +21,39 @@ using Serilog.Formatting.Compact;
 using Serilog.Formatting.Json;
 using Serilog.Sinks.Seq.Http;
 
-namespace Serilog.Sinks.Seq.Audit
+namespace Serilog.Sinks.Seq.Audit;
+
+/// <summary>
+/// An <see cref="ILogEventSink"/> that synchronously propagates all <see cref="Emit"/> failures as exceptions.
+/// </summary>
+sealed class SeqAuditSink : ILogEventSink, IDisposable
 {
-    /// <summary>
-    /// An <see cref="ILogEventSink"/> that synchronously propagates all <see cref="Emit"/> failures as exceptions.
-    /// </summary>
-    sealed class SeqAuditSink : ILogEventSink, IDisposable
+    readonly SeqIngestionApi _ingestionApi;
+
+    static readonly JsonValueFormatter JsonValueFormatter = new("$type");
+
+    public SeqAuditSink(SeqIngestionApi ingestionApi)
     {
-        readonly SeqIngestionApi _ingestionApi;
+        _ingestionApi = ingestionApi ?? throw new ArgumentNullException(nameof(ingestionApi));
+    }
 
-        static readonly JsonValueFormatter JsonValueFormatter = new("$type");
+    public void Dispose()
+    {
+        _ingestionApi.Dispose();
+    }
 
-        public SeqAuditSink(SeqIngestionApi ingestionApi)
-        {
-            _ingestionApi = ingestionApi ?? throw new ArgumentNullException(nameof(ingestionApi));
-        }
+    public void Emit(LogEvent logEvent)
+    {
+        EmitAsync(logEvent).Wait();
+    }
 
-        public void Dispose()
-        {
-            _ingestionApi.Dispose();
-        }
+    async Task EmitAsync(LogEvent logEvent)
+    {
+        if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
 
-        public void Emit(LogEvent logEvent)
-        {
-            EmitAsync(logEvent).Wait();
-        }
+        var payload = new StringWriter();
+        CompactJsonFormatter.FormatEvent(logEvent, payload, JsonValueFormatter);
 
-        async Task EmitAsync(LogEvent logEvent)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-
-            var payload = new StringWriter();
-            CompactJsonFormatter.FormatEvent(logEvent, payload, JsonValueFormatter);
-
-            await _ingestionApi.IngestAsync(payload.ToString()).ConfigureAwait(false);
-        }
+        await _ingestionApi.IngestAsync(payload.ToString()).ConfigureAwait(false);
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Batched/BatchedSeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Batched/BatchedSeqSink.cs
@@ -21,62 +21,61 @@ using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
 using Serilog.Sinks.Seq.Http;
 
-namespace Serilog.Sinks.Seq.Batched
+namespace Serilog.Sinks.Seq.Batched;
+
+/// <summary>
+/// The default Seq sink, for use in combination with <see cref="PeriodicBatchingSink"/>.
+/// </summary>
+sealed class BatchedSeqSink : IBatchedLogEventSink, IDisposable
 {
-    /// <summary>
-    /// The default Seq sink, for use in combination with <see cref="PeriodicBatchingSink"/>.
-    /// </summary>
-    sealed class BatchedSeqSink : IBatchedLogEventSink, IDisposable
+    static readonly TimeSpan RequiredLevelCheckInterval = TimeSpan.FromMinutes(2);
+
+    readonly ConstrainedBufferedFormatter _formatter;
+    readonly SeqIngestionApi _ingestionApi;
+
+    DateTime _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
+    readonly ControlledLevelSwitch _controlledSwitch;
+
+    public BatchedSeqSink(
+        SeqIngestionApi ingestionApi,
+        long? eventBodyLimitBytes,
+        ControlledLevelSwitch controlledSwitch)
     {
-        static readonly TimeSpan RequiredLevelCheckInterval = TimeSpan.FromMinutes(2);
+        _controlledSwitch = controlledSwitch ?? throw new ArgumentNullException(nameof(controlledSwitch));
+        _formatter = new ConstrainedBufferedFormatter(eventBodyLimitBytes);
+        _ingestionApi = ingestionApi ?? throw new ArgumentNullException(nameof(ingestionApi));
+    }
 
-        readonly ConstrainedBufferedFormatter _formatter;
-        readonly SeqIngestionApi _ingestionApi;
+    public void Dispose()
+    {
+        _ingestionApi.Dispose();
+    }
 
-        DateTime _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
-        readonly ControlledLevelSwitch _controlledSwitch;
-
-        public BatchedSeqSink(
-            SeqIngestionApi ingestionApi,
-            long? eventBodyLimitBytes,
-            ControlledLevelSwitch controlledSwitch)
+    // The sink must emit at least one event on startup, and the server be
+    // configured to set a specific level, before background level checks will be performed.
+    public async Task OnEmptyBatchAsync()
+    {
+        if (_controlledSwitch.IsActive &&
+            _nextRequiredLevelCheckUtc < DateTime.UtcNow)
         {
-            _controlledSwitch = controlledSwitch ?? throw new ArgumentNullException(nameof(controlledSwitch));
-            _formatter = new ConstrainedBufferedFormatter(eventBodyLimitBytes);
-            _ingestionApi = ingestionApi ?? throw new ArgumentNullException(nameof(ingestionApi));
+            await EmitBatchAsync(Enumerable.Empty<LogEvent>());
+        }
+    }
+
+    public async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+    {
+        _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
+
+        var payload = new StringWriter();
+        foreach (var evt in events)
+        {
+            _formatter.Format(evt, payload);
         }
 
-        public void Dispose()
-        {
-            _ingestionApi.Dispose();
-        }
+        var clefPayload = payload.ToString();
 
-        // The sink must emit at least one event on startup, and the server be
-        // configured to set a specific level, before background level checks will be performed.
-        public async Task OnEmptyBatchAsync()
-        {
-            if (_controlledSwitch.IsActive &&
-                _nextRequiredLevelCheckUtc < DateTime.UtcNow)
-            {
-                await EmitBatchAsync(Enumerable.Empty<LogEvent>());
-            }
-        }
+        var minimumAcceptedLevel = await _ingestionApi.IngestAsync(clefPayload);
 
-        public async Task EmitBatchAsync(IEnumerable<LogEvent> events)
-        {
-            _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
-
-            var payload = new StringWriter();
-            foreach (var evt in events)
-            {
-                _formatter.Format(evt, payload);
-            }
-
-            var clefPayload = payload.ToString();
-
-            var minimumAcceptedLevel = await _ingestionApi.IngestAsync(clefPayload);
-
-            _controlledSwitch.Update(minimumAcceptedLevel);
-        }
+        _controlledSwitch.Update(minimumAcceptedLevel);
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
@@ -22,120 +22,119 @@ using Serilog.Formatting.Compact;
 using Serilog.Formatting.Json;
 using Serilog.Parsing;
 
-namespace Serilog.Sinks.Seq
+namespace Serilog.Sinks.Seq;
+
+/// <summary>
+/// Wraps a <see cref="CompactJsonFormatter" /> to suppress formatting errors and apply the event body size
+/// limit, if any. Placeholder events are logged when an event is unable to be written itself.
+/// </summary>
+sealed class ConstrainedBufferedFormatter : ITextFormatter
 {
-    /// <summary>
-    /// Wraps a <see cref="CompactJsonFormatter" /> to suppress formatting errors and apply the event body size
-    /// limit, if any. Placeholder events are logged when an event is unable to be written itself.
-    /// </summary>
-    sealed class ConstrainedBufferedFormatter : ITextFormatter
+    static readonly int NewLineByteCount = Encoding.UTF8.GetByteCount(Environment.NewLine);
+        
+    readonly long? _eventBodyLimitBytes;
+    readonly CompactJsonFormatter _jsonFormatter = new(new JsonValueFormatter("$type"));
+
+    public ConstrainedBufferedFormatter(long? eventBodyLimitBytes)
     {
-        static readonly int NewLineByteCount = Encoding.UTF8.GetByteCount(Environment.NewLine);
+        _eventBodyLimitBytes = eventBodyLimitBytes;
+    }
+
+    public void Format(LogEvent logEvent, TextWriter output)
+    {
+        Format(logEvent, output, writePlaceholders: true);
+    }
         
-        readonly long? _eventBodyLimitBytes;
-        readonly CompactJsonFormatter _jsonFormatter = new(new JsonValueFormatter("$type"));
+    void Format(LogEvent logEvent, TextWriter output, bool writePlaceholders)
+    {
+        var buffer = new StringWriter();
 
-        public ConstrainedBufferedFormatter(long? eventBodyLimitBytes)
+        try
         {
-            _eventBodyLimitBytes = eventBodyLimitBytes;
+            _jsonFormatter.Format(logEvent, buffer);
         }
-
-        public void Format(LogEvent logEvent, TextWriter output)
+        catch (Exception ex) when (writePlaceholders)
         {
-            Format(logEvent, output, writePlaceholders: true);
-        }
-        
-        void Format(LogEvent logEvent, TextWriter output, bool writePlaceholders)
-        {
-            var buffer = new StringWriter();
-
-            try
-            {
-                _jsonFormatter.Format(logEvent, buffer);
-            }
-            catch (Exception ex) when (writePlaceholders)
-            {
-                SelfLog.WriteLine(
-                    "Event with message template {0} at {1} could not be formatted as JSON and will be dropped: {2}",
-                    logEvent.MessageTemplate.Text, logEvent.Timestamp, ex);
+            SelfLog.WriteLine(
+                "Event with message template {0} at {1} could not be formatted as JSON and will be dropped: {2}",
+                logEvent.MessageTemplate.Text, logEvent.Timestamp, ex);
                 
-                var placeholder = CreateNonFormattableEventPlaceholder(logEvent, ex);
+            var placeholder = CreateNonFormattableEventPlaceholder(logEvent, ex);
+            Format(placeholder, output, writePlaceholders: false);
+            return;
+        }
+
+        var jsonLine = buffer.ToString();
+        if (CheckEventBodySize(jsonLine, _eventBodyLimitBytes))
+        {
+            output.Write(jsonLine);
+        }
+        else
+        {
+            SelfLog.WriteLine(
+                "Event JSON representation exceeds the byte size limit of {0} set for this Seq sink and will be dropped; data: {1}",
+                _eventBodyLimitBytes, jsonLine);
+                
+            if (writePlaceholders)
+            {
+                var placeholder = CreateOversizeEventPlaceholder(logEvent, jsonLine, _eventBodyLimitBytes!.Value);
                 Format(placeholder, output, writePlaceholders: false);
-                return;
-            }
-
-            var jsonLine = buffer.ToString();
-            if (CheckEventBodySize(jsonLine, _eventBodyLimitBytes))
-            {
-                output.Write(jsonLine);
-            }
-            else
-            {
-                SelfLog.WriteLine(
-                    "Event JSON representation exceeds the byte size limit of {0} set for this Seq sink and will be dropped; data: {1}",
-                    _eventBodyLimitBytes, jsonLine);
-                
-                if (writePlaceholders)
-                {
-                    var placeholder = CreateOversizeEventPlaceholder(logEvent, jsonLine, _eventBodyLimitBytes!.Value);
-                    Format(placeholder, output, writePlaceholders: false);
-                }
             }
         }
+    }
 
-        static LogEvent CreateNonFormattableEventPlaceholder(LogEvent logEvent, Exception ex)
-        {
-            return new LogEvent(
-                logEvent.Timestamp,
-                LogEventLevel.Error,
-                ex,
-                new MessageTemplateParser().Parse("Event with message template {OriginalMessageTemplate} could not be formatted as JSON"),
-                new[]
-                {
-                    new LogEventProperty("OriginalMessageTemplate", new ScalarValue(logEvent.MessageTemplate.Text)),
-                });
-        }
+    static LogEvent CreateNonFormattableEventPlaceholder(LogEvent logEvent, Exception ex)
+    {
+        return new LogEvent(
+            logEvent.Timestamp,
+            LogEventLevel.Error,
+            ex,
+            new MessageTemplateParser().Parse("Event with message template {OriginalMessageTemplate} could not be formatted as JSON"),
+            new[]
+            {
+                new LogEventProperty("OriginalMessageTemplate", new ScalarValue(logEvent.MessageTemplate.Text)),
+            });
+    }
 
-        static bool CheckEventBodySize(string jsonLine, long? eventBodyLimitBytes)
-        {
-            if (eventBodyLimitBytes == null)
-                return true;
+    static bool CheckEventBodySize(string jsonLine, long? eventBodyLimitBytes)
+    {
+        if (eventBodyLimitBytes == null)
+            return true;
             
-            var byteCount = Encoding.UTF8.GetByteCount(jsonLine) - NewLineByteCount;
-            return byteCount <= eventBodyLimitBytes;
-        }
+        var byteCount = Encoding.UTF8.GetByteCount(jsonLine) - NewLineByteCount;
+        return byteCount <= eventBodyLimitBytes;
+    }
         
-        static LogEvent CreateOversizeEventPlaceholder(LogEvent logEvent, string jsonLine, long eventBodyLimitBytes)
-        {
-            var sampleLength = GetOversizeEventSampleLength(eventBodyLimitBytes);
-            var sample = jsonLine.Substring(0, Math.Min(jsonLine.Length, (int)sampleLength));
-            return new LogEvent(
-                logEvent.Timestamp,
-                LogEventLevel.Error,
-                exception: null,
-                new MessageTemplateParser().Parse("Event JSON representation exceeds the body size limit {EventBodyLimitBytes}; sample: {EventBodySample}"),
-                new[]
-                {
-                    new LogEventProperty("EventBodyLimitBytes", new ScalarValue(eventBodyLimitBytes)),
-                    new LogEventProperty("EventBodySample", new ScalarValue(sample)),
-                });
-        }
+    static LogEvent CreateOversizeEventPlaceholder(LogEvent logEvent, string jsonLine, long eventBodyLimitBytes)
+    {
+        var sampleLength = GetOversizeEventSampleLength(eventBodyLimitBytes);
+        var sample = jsonLine.Substring(0, Math.Min(jsonLine.Length, (int)sampleLength));
+        return new LogEvent(
+            logEvent.Timestamp,
+            LogEventLevel.Error,
+            exception: null,
+            new MessageTemplateParser().Parse("Event JSON representation exceeds the body size limit {EventBodyLimitBytes}; sample: {EventBodySample}"),
+            new[]
+            {
+                new LogEventProperty("EventBodyLimitBytes", new ScalarValue(eventBodyLimitBytes)),
+                new LogEventProperty("EventBodySample", new ScalarValue(sample)),
+            });
+    }
 
-        internal static long GetOversizeEventSampleLength(long eventBodyLimitBytes)
-        {
-            // A quick estimate of how much of the original event payload we should send along with the oversized event
-            // placeholder. If the limit is so constrained as to disallow sending the sample, that's okay - we'll
-            // just drop the placeholder, too.
+    internal static long GetOversizeEventSampleLength(long eventBodyLimitBytes)
+    {
+        // A quick estimate of how much of the original event payload we should send along with the oversized event
+        // placeholder. If the limit is so constrained as to disallow sending the sample, that's okay - we'll
+        // just drop the placeholder, too.
             
-            // In reality the timestamp and other envelope components won't be anything close to this.
-            const long packagingAllowance = 2048;
-            var byteBudget = eventBodyLimitBytes - packagingAllowance;
+        // In reality the timestamp and other envelope components won't be anything close to this.
+        const long packagingAllowance = 2048;
+        var byteBudget = eventBodyLimitBytes - packagingAllowance;
             
-            // Allow for multibyte characters and JSON escape sequences.
-            var withEncoding = byteBudget / 2;
+        // Allow for multibyte characters and JSON escape sequences.
+        var withEncoding = byteBudget / 2;
 
-            const long minimumSampleSize = 512;
-            return Math.Max(withEncoding, minimumSampleSize);
-        }
+        const long minimumSampleSize = 512;
+        return Math.Max(withEncoding, minimumSampleSize);
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/ControlledLevelSwitch.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/ControlledLevelSwitch.cs
@@ -15,57 +15,56 @@
 using Serilog.Core;
 using Serilog.Events;
 
-namespace Serilog.Sinks.Seq
+namespace Serilog.Sinks.Seq;
+
+/// <summary>
+/// Instances of this type are single-threaded, generally only updated on a background
+/// timer thread. An exception is <see cref="IsIncluded(LogEvent)"/>, which may be called
+/// concurrently but performs no synchronization.
+/// </summary>
+sealed class ControlledLevelSwitch
 {
-    /// <summary>
-    /// Instances of this type are single-threaded, generally only updated on a background
-    /// timer thread. An exception is <see cref="IsIncluded(LogEvent)"/>, which may be called
-    /// concurrently but performs no synchronization.
-    /// </summary>
-    sealed class ControlledLevelSwitch
+    // If non-null, then background level checks will be performed; set either through the constructor
+    // or in response to a level specification from the server. Never set to null after being made non-null.
+    LoggingLevelSwitch? _controlledSwitch;
+    LogEventLevel? _originalLevel;
+
+    public ControlledLevelSwitch(LoggingLevelSwitch? controlledSwitch = null)
     {
-        // If non-null, then background level checks will be performed; set either through the constructor
-        // or in response to a level specification from the server. Never set to null after being made non-null.
-        LoggingLevelSwitch? _controlledSwitch;
-        LogEventLevel? _originalLevel;
+        _controlledSwitch = controlledSwitch;
+    }
 
-        public ControlledLevelSwitch(LoggingLevelSwitch? controlledSwitch = null)
+    public bool IsActive => _controlledSwitch != null;
+
+    public bool IsIncluded(LogEvent evt)
+    {
+        // Concurrent, but not synchronized.
+        var controlledSwitch = _controlledSwitch;
+        return controlledSwitch == null ||
+               (int)controlledSwitch.MinimumLevel <= (int)evt.Level;
+    }
+
+    public void Update(LogEventLevel? minimumAcceptedLevel)
+    {
+        if (minimumAcceptedLevel == null)
         {
-            _controlledSwitch = controlledSwitch;
+            if (_controlledSwitch != null && _originalLevel.HasValue)
+                _controlledSwitch.MinimumLevel = _originalLevel.Value;
+
+            return;
         }
 
-        public bool IsActive => _controlledSwitch != null;
-
-        public bool IsIncluded(LogEvent evt)
+        if (_controlledSwitch == null)
         {
-            // Concurrent, but not synchronized.
-            var controlledSwitch = _controlledSwitch;
-            return controlledSwitch == null ||
-                (int)controlledSwitch.MinimumLevel <= (int)evt.Level;
+            // The server is controlling the logging level, but not the overall logger. Hence, if the server
+            // stops controlling the level, the switch should become transparent.
+            _originalLevel = LevelAlias.Minimum;
+            _controlledSwitch = new LoggingLevelSwitch(minimumAcceptedLevel.Value);
+            return;
         }
 
-        public void Update(LogEventLevel? minimumAcceptedLevel)
-        {
-            if (minimumAcceptedLevel == null)
-            {
-                if (_controlledSwitch != null && _originalLevel.HasValue)
-                    _controlledSwitch.MinimumLevel = _originalLevel.Value;
+        _originalLevel ??= _controlledSwitch.MinimumLevel;
 
-                return;
-            }
-
-            if (_controlledSwitch == null)
-            {
-                // The server is controlling the logging level, but not the overall logger. Hence, if the server
-                // stops controlling the level, the switch should become transparent.
-                _originalLevel = LevelAlias.Minimum;
-                _controlledSwitch = new LoggingLevelSwitch(minimumAcceptedLevel.Value);
-                return;
-            }
-
-            _originalLevel ??= _controlledSwitch.MinimumLevel;
-
-            _controlledSwitch.MinimumLevel = minimumAcceptedLevel.Value;
-        }
+        _controlledSwitch.MinimumLevel = minimumAcceptedLevel.Value;
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/BookmarkFile.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/BookmarkFile.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if DURABLE
-
 using System;
 using System.IO;
 using System.Text;
@@ -73,5 +71,3 @@ namespace Serilog.Sinks.Seq.Durable
         }
     }
 }
-
-#endif

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/DurableSeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/DurableSeqSink.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if DURABLE
-
 using System;
 using Serilog.Core;
 using Serilog.Events;
@@ -96,5 +94,3 @@ namespace Serilog.Sinks.Seq.Durable
         }
     }
 }
-
-#endif

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/ExponentialBackoffConnectionSchedule.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/ExponentialBackoffConnectionSchedule.cs
@@ -14,63 +14,61 @@
 
 using System;
 
-namespace Serilog.Sinks.Seq.Durable
+namespace Serilog.Sinks.Seq.Durable;
+
+/// <summary>
+/// Based on the BatchedConnectionStatus class from <see cref="Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink"/>.
+/// </summary>
+sealed class ExponentialBackoffConnectionSchedule
 {
-    /// <summary>
-    /// Based on the BatchedConnectionStatus class from <see cref="Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink"/>.
-    /// </summary>
-    sealed class ExponentialBackoffConnectionSchedule
+    static readonly TimeSpan MinimumBackoffPeriod = TimeSpan.FromSeconds(5);
+    static readonly TimeSpan MaximumBackoffInterval = TimeSpan.FromMinutes(10);
+
+    readonly TimeSpan _period;
+
+    int _failuresSinceSuccessfulConnection;
+
+    public ExponentialBackoffConnectionSchedule(TimeSpan period)
     {
-        static readonly TimeSpan MinimumBackoffPeriod = TimeSpan.FromSeconds(5);
-        static readonly TimeSpan MaximumBackoffInterval = TimeSpan.FromMinutes(10);
-
-        readonly TimeSpan _period;
-
-        int _failuresSinceSuccessfulConnection;
-
-        public ExponentialBackoffConnectionSchedule(TimeSpan period)
-        {
-            if (period < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), "The connection retry period must be a positive timespan");
+        if (period < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), "The connection retry period must be a positive timespan");
        
-            _period = period;
-        }
+        _period = period;
+    }
 
-        public void MarkSuccess()
+    public void MarkSuccess()
+    {
+        _failuresSinceSuccessfulConnection = 0;
+    }
+
+    public void MarkFailure()
+    {
+        ++_failuresSinceSuccessfulConnection;
+    }
+
+    public TimeSpan NextInterval
+    {
+        get
         {
-            _failuresSinceSuccessfulConnection = 0;
-        }
+            // Available, and first failure, just try the batch interval
+            if (_failuresSinceSuccessfulConnection <= 1) return _period;
 
-        public void MarkFailure()
-        {
-            ++_failuresSinceSuccessfulConnection;
-        }
+            // Second failure, start ramping up the interval - first 2x, then 4x, ...
+            var backoffFactor = Math.Pow(2, (_failuresSinceSuccessfulConnection - 1));
 
-        public TimeSpan NextInterval
-        {
-            get
-            {
-                // Available, and first failure, just try the batch interval
-                if (_failuresSinceSuccessfulConnection <= 1) return _period;
+            // If the period is ridiculously short, give it a boost so we get some
+            // visible backoff.
+            var backoffPeriod = Math.Max(_period.Ticks, MinimumBackoffPeriod.Ticks);
 
-                // Second failure, start ramping up the interval - first 2x, then 4x, ...
-                var backoffFactor = Math.Pow(2, (_failuresSinceSuccessfulConnection - 1));
+            // The "ideal" interval
+            var backedOff = (long)(backoffPeriod * backoffFactor);
 
-                // If the period is ridiculously short, give it a boost so we get some
-                // visible backoff.
-                var backoffPeriod = Math.Max(_period.Ticks, MinimumBackoffPeriod.Ticks);
+            // Capped to the maximum interval
+            var cappedBackoff = Math.Min(MaximumBackoffInterval.Ticks, backedOff);
 
-                // The "ideal" interval
-                var backedOff = (long)(backoffPeriod * backoffFactor);
+            // Unless that's shorter than the base interval, in which case we'll just apply the period
+            var actual = Math.Max(_period.Ticks, cappedBackoff);
 
-                // Capped to the maximum interval
-                var cappedBackoff = Math.Min(MaximumBackoffInterval.Ticks, backedOff);
-
-                // Unless that's shorter than the base interval, in which case we'll just apply the period
-                var actual = Math.Max(_period.Ticks, cappedBackoff);
-
-                return TimeSpan.FromTicks(actual);
-            }
+            return TimeSpan.FromTicks(actual);
         }
     }
 }
-

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSet.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSet.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if DURABLE
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -130,5 +128,3 @@ namespace Serilog.Sinks.Seq.Durable
         }
     }
 }
-
-#endif

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSet.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSet.cs
@@ -20,110 +20,109 @@ using System.Net;
 using System.Text.RegularExpressions;
 using Serilog.Debugging;
 
-namespace Serilog.Sinks.Seq.Durable
+namespace Serilog.Sinks.Seq.Durable;
+
+sealed class FileSet
 {
-    sealed class FileSet
+    readonly string _bookmarkFilename;
+    readonly string _candidateSearchPath;
+    readonly string _logFolder;
+    readonly Regex _filenameMatcher;
+
+    const string InvalidPayloadFilePrefix = "invalid-";
+
+    public string RollingFilePathFormat { get; }
+
+    public FileSet(string bufferBaseFilename)
     {
-        readonly string _bookmarkFilename;
-        readonly string _candidateSearchPath;
-        readonly string _logFolder;
-        readonly Regex _filenameMatcher;
+        if (bufferBaseFilename == null) throw new ArgumentNullException(nameof(bufferBaseFilename));
 
-        const string InvalidPayloadFilePrefix = "invalid-";
-
-        public string RollingFilePathFormat { get; }
-
-        public FileSet(string bufferBaseFilename)
-        {
-            if (bufferBaseFilename == null) throw new ArgumentNullException(nameof(bufferBaseFilename));
-
-            RollingFilePathFormat = bufferBaseFilename + "-.clef";
+        RollingFilePathFormat = bufferBaseFilename + "-.clef";
             
-            _bookmarkFilename = Path.GetFullPath(bufferBaseFilename + ".bookmark");
-            _logFolder = Path.GetDirectoryName(_bookmarkFilename) ?? throw new ArgumentException("Buffer base filename must refer to a regular file.");
+        _bookmarkFilename = Path.GetFullPath(bufferBaseFilename + ".bookmark");
+        _logFolder = Path.GetDirectoryName(_bookmarkFilename) ?? throw new ArgumentException("Buffer base filename must refer to a regular file.");
             
-            // The extension cannot be matched here because it may be either "json" (raw format) or "clef" (compact).
-            _candidateSearchPath = Path.GetFileName(bufferBaseFilename) + "-*.*";
+        // The extension cannot be matched here because it may be either "json" (raw format) or "clef" (compact).
+        _candidateSearchPath = Path.GetFileName(bufferBaseFilename) + "-*.*";
             
-            _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>\\d{8})(?<sequence>_[0-9]{3,}){0,1}\\.(?<ext>json|clef)$");
-        }
+        _filenameMatcher = new Regex("^" + Regex.Escape(Path.GetFileName(bufferBaseFilename)) + "-(?<date>\\d{8})(?<sequence>_[0-9]{3,}){0,1}\\.(?<ext>json|clef)$");
+    }
 
-        public BookmarkFile OpenBookmarkFile()
-        {
-            return new BookmarkFile(_bookmarkFilename);
-        }
+    public BookmarkFile OpenBookmarkFile()
+    {
+        return new BookmarkFile(_bookmarkFilename);
+    }
 
-        public string[] GetBufferFiles()
-        {
-            return Directory.GetFiles(_logFolder, _candidateSearchPath)
-                .Select(n => new KeyValuePair<string, Match>(n, _filenameMatcher.Match(Path.GetFileName(n))))
-                .Where(nm => nm.Value.Success)
-                .OrderBy(nm => nm.Value.Groups["date"].Value, StringComparer.OrdinalIgnoreCase)
-                .ThenByDescending(nm => nm.Value.Groups["ext"].Value)
-                .ThenBy(nm => int.Parse("0" + nm.Value.Groups["sequence"].Value.Replace("_", "")))
-                .Select(nm => nm.Key)
-                .ToArray();
-        }
+    public string[] GetBufferFiles()
+    {
+        return Directory.GetFiles(_logFolder, _candidateSearchPath)
+            .Select(n => new KeyValuePair<string, Match>(n, _filenameMatcher.Match(Path.GetFileName(n))))
+            .Where(nm => nm.Value.Success)
+            .OrderBy(nm => nm.Value.Groups["date"].Value, StringComparer.OrdinalIgnoreCase)
+            .ThenByDescending(nm => nm.Value.Groups["ext"].Value)
+            .ThenBy(nm => int.Parse("0" + nm.Value.Groups["sequence"].Value.Replace("_", "")))
+            .Select(nm => nm.Key)
+            .ToArray();
+    }
 
-        public void CleanUpBufferFiles(long bufferSizeLimitBytes)
+    public void CleanUpBufferFiles(long bufferSizeLimitBytes)
+    {
+        try
         {
+            var bufferFiles = GetBufferFiles();
+            Array.Reverse(bufferFiles);
+            DeleteExceedingCumulativeSize(bufferFiles.Select(f => new FileInfo(f)), bufferSizeLimitBytes, 2);
+        }
+        catch (Exception ex)
+        {
+            SelfLog.WriteLine("Exception thrown while cleaning up buffer files: {0}", ex);
+        }
+    }
+
+    public string MakeInvalidPayloadFilename(HttpStatusCode statusCode)
+    {
+        var invalidPayloadFilename = $"{InvalidPayloadFilePrefix}{statusCode}-{Guid.NewGuid():n}.json";
+        return Path.Combine(_logFolder, invalidPayloadFilename);
+    }
+
+    public void CleanUpInvalidPayloadFiles(long maxNumberOfBytesToRetain)
+    {
+        try
+        {
+            var candidateFiles = from file in Directory.EnumerateFiles(_logFolder, $"{InvalidPayloadFilePrefix}*.json")
+                let candidateFileInfo = new FileInfo(file)
+                orderby candidateFileInfo.LastWriteTimeUtc descending
+                select candidateFileInfo;
+
+            DeleteExceedingCumulativeSize(candidateFiles, maxNumberOfBytesToRetain, 0);
+        }
+        catch (Exception ex)
+        {
+            SelfLog.WriteLine("Exception thrown while cleaning up invalid payload files: {0}", ex);
+        }
+    }
+
+    static void DeleteExceedingCumulativeSize(IEnumerable<FileInfo> files, long maxNumberOfBytesToRetain, int alwaysRetainCount)
+    {
+        long cumulative = 0;
+        var i = 0;
+        foreach (var file in files)
+        {
+            cumulative += file.Length;
+
+            if (i++ < alwaysRetainCount)
+                continue;
+
+            if (cumulative <= maxNumberOfBytesToRetain)
+                continue;
+
             try
             {
-                var bufferFiles = GetBufferFiles();
-                Array.Reverse(bufferFiles);
-                DeleteExceedingCumulativeSize(bufferFiles.Select(f => new FileInfo(f)), bufferSizeLimitBytes, 2);
+                file.Delete();
             }
             catch (Exception ex)
             {
-                SelfLog.WriteLine("Exception thrown while cleaning up buffer files: {0}", ex);
-            }
-        }
-
-        public string MakeInvalidPayloadFilename(HttpStatusCode statusCode)
-        {
-            var invalidPayloadFilename = $"{InvalidPayloadFilePrefix}{statusCode}-{Guid.NewGuid():n}.json";
-            return Path.Combine(_logFolder, invalidPayloadFilename);
-        }
-
-        public void CleanUpInvalidPayloadFiles(long maxNumberOfBytesToRetain)
-        {
-            try
-            {
-                var candidateFiles = from file in Directory.EnumerateFiles(_logFolder, $"{InvalidPayloadFilePrefix}*.json")
-                                     let candidateFileInfo = new FileInfo(file)
-                                     orderby candidateFileInfo.LastWriteTimeUtc descending
-                                     select candidateFileInfo;
-
-                DeleteExceedingCumulativeSize(candidateFiles, maxNumberOfBytesToRetain, 0);
-            }
-            catch (Exception ex)
-            {
-                SelfLog.WriteLine("Exception thrown while cleaning up invalid payload files: {0}", ex);
-            }
-        }
-
-        static void DeleteExceedingCumulativeSize(IEnumerable<FileInfo> files, long maxNumberOfBytesToRetain, int alwaysRetainCount)
-        {
-            long cumulative = 0;
-            var i = 0;
-            foreach (var file in files)
-            {
-                cumulative += file.Length;
-
-                if (i++ < alwaysRetainCount)
-                    continue;
-
-                if (cumulative <= maxNumberOfBytesToRetain)
-                    continue;
-
-                try
-                {
-                    file.Delete();
-                }
-                catch (Exception ex)
-                {
-                    SelfLog.WriteLine("Exception thrown while trying to delete file {0}: {1}", file.FullName, ex);
-                }
+                SelfLog.WriteLine("Exception thrown while trying to delete file {0}: {1}", file.FullName, ex);
             }
         }
     }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSetPosition.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSetPosition.cs
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Serilog.Sinks.Seq.Durable
+namespace Serilog.Sinks.Seq.Durable;
+
+readonly struct FileSetPosition
 {
-    readonly struct FileSetPosition
+    public string? File { get; }
+
+    public long NextLineStart { get; }
+
+    public FileSetPosition(long nextLineStart, string? file)
     {
-        public string? File { get; }
-
-        public long NextLineStart { get; }
-
-        public FileSetPosition(long nextLineStart, string? file)
-        {
-            NextLineStart = nextLineStart;
-            File = file;
-        }
-
-        public static readonly FileSetPosition None = default;
+        NextLineStart = nextLineStart;
+        File = file;
     }
+
+    public static readonly FileSetPosition None = default;
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSetPosition.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/FileSetPosition.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if DURABLE
-
 namespace Serilog.Sinks.Seq.Durable
 {
     readonly struct FileSetPosition
@@ -31,5 +29,3 @@ namespace Serilog.Sinks.Seq.Durable
         public static readonly FileSetPosition None = default;
     }
 }
-
-#endif

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/HttpLogShipper.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if DURABLE
-
 using System;
 using System.IO;
 using System.Linq;
@@ -280,5 +278,3 @@ namespace Serilog.Sinks.Seq.Durable
         }
     }
 }
-
-#endif

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/HttpLogShipper.cs
@@ -27,80 +27,80 @@ using Serilog.Sinks.Seq.Http;
 using System.Runtime.InteropServices;
 #endif
 
-namespace Serilog.Sinks.Seq.Durable
-{
-    sealed class HttpLogShipper : IDisposable
+namespace Serilog.Sinks.Seq.Durable;
+
+sealed class HttpLogShipper : IDisposable
 #if ASYNC_DISPOSE
         , IAsyncDisposable
 #endif
+{
+    static readonly TimeSpan RequiredLevelCheckInterval = TimeSpan.FromMinutes(2);
+
+    readonly int _batchPostingLimit;
+    readonly long? _eventBodyLimitBytes;
+    readonly FileSet _fileSet;
+    readonly long? _retainedInvalidPayloadsLimitBytes;
+    readonly long? _bufferSizeLimitBytes;
+
+    // Timer thread only
+    readonly SeqIngestionApi _ingestionApi;
+
+    readonly ExponentialBackoffConnectionSchedule _connectionSchedule;
+    DateTime _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
+
+    // Synchronized
+    readonly object _stateLock = new();
+
+    readonly PortableTimer _timer;
+
+    // Concurrent
+    readonly ControlledLevelSwitch _controlledSwitch;
+
+    volatile bool _unloading;
+
+    public HttpLogShipper(
+        FileSet fileSet,
+        SeqIngestionApi ingestionApi,
+        int batchPostingLimit,
+        TimeSpan period,
+        long? eventBodyLimitBytes,
+        ControlledLevelSwitch controlledSwitch,
+        long? retainedInvalidPayloadsLimitBytes,
+        long? bufferSizeLimitBytes)
     {
-        static readonly TimeSpan RequiredLevelCheckInterval = TimeSpan.FromMinutes(2);
+        _fileSet = fileSet ?? throw new ArgumentNullException(nameof(fileSet));
+        _ingestionApi = ingestionApi ?? throw new ArgumentNullException(nameof(ingestionApi));
+        _batchPostingLimit = batchPostingLimit;
+        _eventBodyLimitBytes = eventBodyLimitBytes;
+        _controlledSwitch = controlledSwitch;
+        _connectionSchedule = new ExponentialBackoffConnectionSchedule(period);
+        _retainedInvalidPayloadsLimitBytes = retainedInvalidPayloadsLimitBytes;
+        _bufferSizeLimitBytes = bufferSizeLimitBytes;
+        _timer = new PortableTimer(_ => OnTick());
 
-        readonly int _batchPostingLimit;
-        readonly long? _eventBodyLimitBytes;
-        readonly FileSet _fileSet;
-        readonly long? _retainedInvalidPayloadsLimitBytes;
-        readonly long? _bufferSizeLimitBytes;
+        SetTimer();
+    }
 
-        // Timer thread only
-        readonly SeqIngestionApi _ingestionApi;
+    public bool IsIncluded(LogEvent logEvent)
+    {
+        return _controlledSwitch.IsIncluded(logEvent);
+    }
 
-        readonly ExponentialBackoffConnectionSchedule _connectionSchedule;
-        DateTime _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
-
-        // Synchronized
-        readonly object _stateLock = new();
-
-        readonly PortableTimer _timer;
-
-        // Concurrent
-        readonly ControlledLevelSwitch _controlledSwitch;
-
-        volatile bool _unloading;
-
-        public HttpLogShipper(
-            FileSet fileSet,
-            SeqIngestionApi ingestionApi,
-            int batchPostingLimit,
-            TimeSpan period,
-            long? eventBodyLimitBytes,
-            ControlledLevelSwitch controlledSwitch,
-            long? retainedInvalidPayloadsLimitBytes,
-            long? bufferSizeLimitBytes)
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        lock (_stateLock)
         {
-            _fileSet = fileSet ?? throw new ArgumentNullException(nameof(fileSet));
-            _ingestionApi = ingestionApi ?? throw new ArgumentNullException(nameof(ingestionApi));
-            _batchPostingLimit = batchPostingLimit;
-            _eventBodyLimitBytes = eventBodyLimitBytes;
-            _controlledSwitch = controlledSwitch;
-            _connectionSchedule = new ExponentialBackoffConnectionSchedule(period);
-            _retainedInvalidPayloadsLimitBytes = retainedInvalidPayloadsLimitBytes;
-            _bufferSizeLimitBytes = bufferSizeLimitBytes;
-            _timer = new PortableTimer(_ => OnTick());
+            if (_unloading)
+                return;
 
-            SetTimer();
+            _unloading = true;
         }
 
-        public bool IsIncluded(LogEvent logEvent)
-        {
-            return _controlledSwitch.IsIncluded(logEvent);
-        }
+        _timer.Dispose();
 
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            lock (_stateLock)
-            {
-                if (_unloading)
-                    return;
-
-                _unloading = true;
-            }
-
-            _timer.Dispose();
-
-            Task.Run(OnTick).Wait();
-        }
+        Task.Run(OnTick).Wait();
+    }
         
 #if ASYNC_DISPOSE
         public async ValueTask DisposeAsync()
@@ -119,141 +119,141 @@ namespace Serilog.Sinks.Seq.Durable
         }
 #endif
         
-        void SetTimer()
-        {
-            // Note, called under _stateLock
-            _timer.Start(_connectionSchedule.NextInterval);
-        }
+    void SetTimer()
+    {
+        // Note, called under _stateLock
+        _timer.Start(_connectionSchedule.NextInterval);
+    }
 
-        async Task OnTick()
+    async Task OnTick()
+    {
+        try
         {
-            try
+            int count;
+            do
             {
-                int count;
-                do
+                count = 0;
+
+                using var bookmarkFile = _fileSet.OpenBookmarkFile();
+                var position = bookmarkFile.TryReadBookmark();
+                var files = _fileSet.GetBufferFiles();
+
+                if (position.File == null || !IOFile.Exists(position.File))
                 {
+                    position = new FileSetPosition(0, files.FirstOrDefault());
+                }
+
+                string payload, mimeType;
+                if (position.File == null)
+                {
+                    payload = PayloadReader.MakeEmptyPayload(out mimeType);
                     count = 0;
+                }
+                else
+                {
+                    payload = PayloadReader.ReadPayload(_batchPostingLimit, _eventBodyLimitBytes, ref position, ref count, out mimeType);
+                }
 
-                    using var bookmarkFile = _fileSet.OpenBookmarkFile();
-                    var position = bookmarkFile.TryReadBookmark();
-                    var files = _fileSet.GetBufferFiles();
+                if (count > 0 || _controlledSwitch.IsActive && _nextRequiredLevelCheckUtc < DateTime.UtcNow)
+                {
+                    _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
 
-                    if (position.File == null || !IOFile.Exists(position.File))
+                    var result = await _ingestionApi.TryIngestAsync(payload, mimeType);
+                    if (result.Succeeded)
                     {
-                        position = new FileSetPosition(0, files.FirstOrDefault());
+                        _connectionSchedule.MarkSuccess();
+                        bookmarkFile.WriteBookmark(position);
+                        _controlledSwitch.Update(result.MinimumAcceptedLevel);
                     }
-
-                    string payload, mimeType;
-                    if (position.File == null)
+                    else if (result.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.RequestEntityTooLarge)
                     {
-                        payload = PayloadReader.MakeEmptyPayload(out mimeType);
-                        count = 0;
-                    }
-                    else
-                    {
-                        payload = PayloadReader.ReadPayload(_batchPostingLimit, _eventBodyLimitBytes, ref position, ref count, out mimeType);
-                    }
-
-                    if (count > 0 || _controlledSwitch.IsActive && _nextRequiredLevelCheckUtc < DateTime.UtcNow)
-                    {
-                        _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
-
-                        var result = await _ingestionApi.TryIngestAsync(payload, mimeType);
-                        if (result.Succeeded)
-                        {
-                            _connectionSchedule.MarkSuccess();
-                            bookmarkFile.WriteBookmark(position);
-                            _controlledSwitch.Update(result.MinimumAcceptedLevel);
-                        }
-                        else if (result.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.RequestEntityTooLarge)
-                        {
-                            // The connection attempt was successful - the payload we sent was the problem.
-                            _connectionSchedule.MarkSuccess();
-
-                            await DumpInvalidPayloadAsync(result.StatusCode, payload).ConfigureAwait(false);
-
-                            bookmarkFile.WriteBookmark(position);
-                        }
-                        else
-                        {
-                            _connectionSchedule.MarkFailure();
-                            SelfLog.WriteLine("Received failed HTTP shipping result {0}", result.StatusCode);
-
-                            if (_bufferSizeLimitBytes.HasValue)
-                                _fileSet.CleanUpBufferFiles(_bufferSizeLimitBytes.Value);
-
-                            break;
-                        }
-                    }
-                    else if (position.File == null)
-                    {
-                        break;
-                    }
-                    else
-                    {
-                        // For whatever reason, there's nothing waiting to send. This means we should try connecting again at the
-                        // regular interval, so mark the attempt as successful.
+                        // The connection attempt was successful - the payload we sent was the problem.
                         _connectionSchedule.MarkSuccess();
 
-                        // Only advance the bookmark if no other process has the
-                        // current file locked, and its length is as we found it.
-                        if (files.Length == 2 && files.First() == position.File &&
-                            FileIsUnlockedAndUnextended(position))
-                        {
-                            bookmarkFile.WriteBookmark(new FileSetPosition(0, files[1]));
-                        }
+                        await DumpInvalidPayloadAsync(result.StatusCode, payload).ConfigureAwait(false);
 
-                        if (files.Length > 2)
-                        {
-                            // By this point, we expect writers to have relinquished locks
-                            // on the oldest file.
-                            IOFile.Delete(files[0]);
-                        }
+                        bookmarkFile.WriteBookmark(position);
                     }
-                } while (count == _batchPostingLimit);
-            }
-            catch (Exception ex)
-            {
-                _connectionSchedule.MarkFailure();
-                SelfLog.WriteLine("Exception while emitting periodic batch from {0}: {1}", this, ex);
+                    else
+                    {
+                        _connectionSchedule.MarkFailure();
+                        SelfLog.WriteLine("Received failed HTTP shipping result {0}", result.StatusCode);
 
-                if (_bufferSizeLimitBytes.HasValue)
-                    _fileSet.CleanUpBufferFiles(_bufferSizeLimitBytes.Value);
-            }
-            finally
-            {
-                lock (_stateLock)
-                {
-                    if (!_unloading)
-                        SetTimer();
+                        if (_bufferSizeLimitBytes.HasValue)
+                            _fileSet.CleanUpBufferFiles(_bufferSizeLimitBytes.Value);
+
+                        break;
+                    }
                 }
+                else if (position.File == null)
+                {
+                    break;
+                }
+                else
+                {
+                    // For whatever reason, there's nothing waiting to send. This means we should try connecting again at the
+                    // regular interval, so mark the attempt as successful.
+                    _connectionSchedule.MarkSuccess();
+
+                    // Only advance the bookmark if no other process has the
+                    // current file locked, and its length is as we found it.
+                    if (files.Length == 2 && files.First() == position.File &&
+                        FileIsUnlockedAndUnextended(position))
+                    {
+                        bookmarkFile.WriteBookmark(new FileSetPosition(0, files[1]));
+                    }
+
+                    if (files.Length > 2)
+                    {
+                        // By this point, we expect writers to have relinquished locks
+                        // on the oldest file.
+                        IOFile.Delete(files[0]);
+                    }
+                }
+            } while (count == _batchPostingLimit);
+        }
+        catch (Exception ex)
+        {
+            _connectionSchedule.MarkFailure();
+            SelfLog.WriteLine("Exception while emitting periodic batch from {0}: {1}", this, ex);
+
+            if (_bufferSizeLimitBytes.HasValue)
+                _fileSet.CleanUpBufferFiles(_bufferSizeLimitBytes.Value);
+        }
+        finally
+        {
+            lock (_stateLock)
+            {
+                if (!_unloading)
+                    SetTimer();
             }
         }
+    }
 
-        Task DumpInvalidPayloadAsync(HttpStatusCode statusCode, string payload)
+    Task DumpInvalidPayloadAsync(HttpStatusCode statusCode, string payload)
+    {
+        var invalidPayloadFile = _fileSet.MakeInvalidPayloadFilename(statusCode);
+        SelfLog.WriteLine("HTTP shipping failed with {0}; dumping payload to {1}", statusCode, invalidPayloadFile);
+        var bytesToWrite = Encoding.UTF8.GetBytes(payload);
+        if (_retainedInvalidPayloadsLimitBytes.HasValue)
         {
-            var invalidPayloadFile = _fileSet.MakeInvalidPayloadFilename(statusCode);
-            SelfLog.WriteLine("HTTP shipping failed with {0}; dumping payload to {1}", statusCode, invalidPayloadFile);
-            var bytesToWrite = Encoding.UTF8.GetBytes(payload);
-            if (_retainedInvalidPayloadsLimitBytes.HasValue)
-            {
-                _fileSet.CleanUpInvalidPayloadFiles(_retainedInvalidPayloadsLimitBytes.Value - bytesToWrite.Length);
-            }
+            _fileSet.CleanUpInvalidPayloadFiles(_retainedInvalidPayloadsLimitBytes.Value - bytesToWrite.Length);
+        }
 #if WRITE_ALL_BYTES_ASYNC
             return IOFile.WriteAllBytesAsync(invalidPayloadFile, bytesToWrite);
 #else
-            IOFile.WriteAllBytes(invalidPayloadFile, bytesToWrite);
-            return Task.FromResult(0);
+        IOFile.WriteAllBytes(invalidPayloadFile, bytesToWrite);
+        return Task.FromResult(0);
 #endif
-        }
+    }
 
-        static bool FileIsUnlockedAndUnextended(FileSetPosition position)
+    static bool FileIsUnlockedAndUnextended(FileSetPosition position)
+    {
+        try
         {
-            try
-            {
-                using var fileStream = IOFile.Open(position.File!, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
-                return fileStream.Length <= position.NextLineStart;
-            }
+            using var fileStream = IOFile.Open(position.File!, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+            return fileStream.Length <= position.NextLineStart;
+        }
 #if HRESULTS
             catch (IOException ex)
             {
@@ -264,17 +264,16 @@ namespace Serilog.Sinks.Seq.Durable
                 }
             }
 #else
-            catch (IOException)
-            {
-                // Where no HRESULT is available, assume IOExceptions indicate a locked file
-            }
-#endif
-            catch (Exception ex)
-            {
-                SelfLog.WriteLine("Unexpected exception while testing locked status of {0}: {1}", position.File, ex);
-            }
-
-            return false;
+        catch (IOException)
+        {
+            // Where no HRESULT is available, assume IOExceptions indicate a locked file
         }
+#endif
+        catch (Exception ex)
+        {
+            SelfLog.WriteLine("Unexpected exception while testing locked status of {0}: {1}", position.File, ex);
+        }
+
+        return false;
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/PayloadReader.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/PayloadReader.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if DURABLE
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -146,5 +144,3 @@ namespace Serilog.Sinks.Seq.Durable
         }
     }
 }
-
-#endif

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/PayloadReader.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/PayloadReader.cs
@@ -19,128 +19,127 @@ using System.Text;
 using Serilog.Debugging;
 using Serilog.Sinks.Seq.Http;
 
-namespace Serilog.Sinks.Seq.Durable
+namespace Serilog.Sinks.Seq.Durable;
+
+static class PayloadReader
 {
-    static class PayloadReader
+    public static string ReadPayload(
+        int batchPostingLimit,
+        long? eventBodyLimitBytes,
+        ref FileSetPosition position,
+        ref int count,
+        out string mimeType)
     {
-        public static string ReadPayload(
-            int batchPostingLimit,
-            long? eventBodyLimitBytes,
-            ref FileSetPosition position,
-            ref int count,
-            out string mimeType)
-        {
-            if (position.File == null) throw new ArgumentException("File set position must point to a file.");
+        if (position.File == null) throw new ArgumentException("File set position must point to a file.");
             
-            if (position.File.EndsWith(".json"))
-            {
-                mimeType = SeqIngestionApi.RawEventFormatMediaType;
-                return ReadRawPayload(batchPostingLimit, eventBodyLimitBytes, ref position, ref count);
-            }
-
-            mimeType = SeqIngestionApi.CompactLogEventFormatMediaType;
-            return ReadCompactPayload(batchPostingLimit, eventBodyLimitBytes, ref position, ref count);
+        if (position.File.EndsWith(".json"))
+        {
+            mimeType = SeqIngestionApi.RawEventFormatMediaType;
+            return ReadRawPayload(batchPostingLimit, eventBodyLimitBytes, ref position, ref count);
         }
 
-        static string ReadCompactPayload(int batchPostingLimit, long? eventBodyLimitBytes, ref FileSetPosition position, ref int count)
+        mimeType = SeqIngestionApi.CompactLogEventFormatMediaType;
+        return ReadCompactPayload(batchPostingLimit, eventBodyLimitBytes, ref position, ref count);
+    }
+
+    static string ReadCompactPayload(int batchPostingLimit, long? eventBodyLimitBytes, ref FileSetPosition position, ref int count)
+    {
+        var payload = new StringWriter();
+
+        using (var current = System.IO.File.Open(position.File!, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
         {
-            var payload = new StringWriter();
-
-            using (var current = System.IO.File.Open(position.File!, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            var nextLineStart = position.NextLineStart;
+            while (count < batchPostingLimit && TryReadLine(current, ref nextLineStart, out var nextLine))
             {
-                var nextLineStart = position.NextLineStart;
-                while (count < batchPostingLimit && TryReadLine(current, ref nextLineStart, out var nextLine))
+                position = new FileSetPosition(nextLineStart, position.File);
+
+                // Count is the indicator that work was done, so advances even in the (rare) case an
+                // oversized event is dropped.
+                ++count;
+
+                if (eventBodyLimitBytes.HasValue && Encoding.UTF8.GetByteCount(nextLine) > eventBodyLimitBytes.Value)
                 {
-                    position = new FileSetPosition(nextLineStart, position.File);
-
-                    // Count is the indicator that work was done, so advances even in the (rare) case an
-                    // oversized event is dropped.
-                    ++count;
-
-                    if (eventBodyLimitBytes.HasValue && Encoding.UTF8.GetByteCount(nextLine) > eventBodyLimitBytes.Value)
-                    {
-                        SelfLog.WriteLine(
-                            "Event JSON representation exceeds the byte size limit of {0} and will be dropped; data: {1}",
-                            eventBodyLimitBytes, nextLine);
-                    }
-                    else
-                    {
-                        payload.WriteLine(nextLine);
-                    }
+                    SelfLog.WriteLine(
+                        "Event JSON representation exceeds the byte size limit of {0} and will be dropped; data: {1}",
+                        eventBodyLimitBytes, nextLine);
+                }
+                else
+                {
+                    payload.WriteLine(nextLine);
                 }
             }
+        }
             
-            return payload.ToString();
-        }
+        return payload.ToString();
+    }
 
 
-        static string ReadRawPayload(int batchPostingLimit, long? eventBodyLimitBytes, ref FileSetPosition position, ref int count)
+    static string ReadRawPayload(int batchPostingLimit, long? eventBodyLimitBytes, ref FileSetPosition position, ref int count)
+    {
+        var payload = new StringWriter();
+        payload.Write("{\"Events\":[");
+        var delimStart = "";
+
+        using (var current = System.IO.File.Open(position.File!, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
         {
-            var payload = new StringWriter();
-            payload.Write("{\"Events\":[");
-            var delimStart = "";
-
-            using (var current = System.IO.File.Open(position.File!, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            var nextLineStart = position.NextLineStart;
+            while (count < batchPostingLimit && TryReadLine(current, ref nextLineStart, out var nextLine))
             {
-                var nextLineStart = position.NextLineStart;
-                while (count < batchPostingLimit && TryReadLine(current, ref nextLineStart, out var nextLine))
+                position = new FileSetPosition(nextLineStart, position.File);
+
+                // Count is the indicator that work was done, so advances even in the (rare) case an
+                // oversized event is dropped.
+                ++count;
+
+                if (eventBodyLimitBytes.HasValue && Encoding.UTF8.GetByteCount(nextLine) > eventBodyLimitBytes.Value)
                 {
-                    position = new FileSetPosition(nextLineStart, position.File);
-
-                    // Count is the indicator that work was done, so advances even in the (rare) case an
-                    // oversized event is dropped.
-                    ++count;
-
-                    if (eventBodyLimitBytes.HasValue && Encoding.UTF8.GetByteCount(nextLine) > eventBodyLimitBytes.Value)
-                    {
-                        SelfLog.WriteLine(
-                            "Event JSON representation exceeds the byte size limit of {0} and will be dropped; data: {1}",
-                            eventBodyLimitBytes, nextLine);
-                    }
-                    else
-                    {
-                        payload.Write(delimStart);
-                        payload.Write(nextLine);
-                        delimStart = ",";
-                    }
+                    SelfLog.WriteLine(
+                        "Event JSON representation exceeds the byte size limit of {0} and will be dropped; data: {1}",
+                        eventBodyLimitBytes, nextLine);
                 }
-
-                payload.Write("]}");
-            }
-            return payload.ToString();
-        }
-
-        // It would be ideal to chomp whitespace here, but not required.
-        static bool TryReadLine(Stream current, ref long nextStart, [NotNullWhen(true)] out string? nextLine)
-        {
-            var includesBom = nextStart == 0;
-
-            if (current.Length <= nextStart)
-            {
-                nextLine = null;
-                return false;
+                else
+                {
+                    payload.Write(delimStart);
+                    payload.Write(nextLine);
+                    delimStart = ",";
+                }
             }
 
-            current.Position = nextStart;
-
-            // Important not to dispose this StreamReader as the stream must remain open.
-            var reader = new StreamReader(current, Encoding.UTF8, false, 128);
-            nextLine = reader.ReadLine();
-
-            if (nextLine == null)
-                return false;
-
-            nextStart += Encoding.UTF8.GetByteCount(nextLine) + Encoding.UTF8.GetByteCount(Environment.NewLine);
-            if (includesBom)
-                nextStart += 3;
-
-            return true;
+            payload.Write("]}");
         }
+        return payload.ToString();
+    }
 
-        public static string MakeEmptyPayload(out string mimeType)
+    // It would be ideal to chomp whitespace here, but not required.
+    static bool TryReadLine(Stream current, ref long nextStart, [NotNullWhen(true)] out string? nextLine)
+    {
+        var includesBom = nextStart == 0;
+
+        if (current.Length <= nextStart)
         {
-            mimeType = SeqIngestionApi.CompactLogEventFormatMediaType;
-            return SeqIngestionApi.EmptyClefPayload;
+            nextLine = null;
+            return false;
         }
+
+        current.Position = nextStart;
+
+        // Important not to dispose this StreamReader as the stream must remain open.
+        var reader = new StreamReader(current, Encoding.UTF8, false, 128);
+        nextLine = reader.ReadLine();
+
+        if (nextLine == null)
+            return false;
+
+        nextStart += Encoding.UTF8.GetByteCount(nextLine) + Encoding.UTF8.GetByteCount(Environment.NewLine);
+        if (includesBom)
+            nextStart += 3;
+
+        return true;
+    }
+
+    public static string MakeEmptyPayload(out string mimeType)
+    {
+        mimeType = SeqIngestionApi.CompactLogEventFormatMediaType;
+        return SeqIngestionApi.EmptyClefPayload;
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Http/IngestionResult.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Http/IngestionResult.cs
@@ -15,41 +15,40 @@
 using System.Net;
 using Serilog.Events;
 
-namespace Serilog.Sinks.Seq.Http
+namespace Serilog.Sinks.Seq.Http;
+
+/// <summary>
+/// The result of a POST to the ingestion API.
+/// </summary>
+readonly struct IngestionResult
 {
     /// <summary>
-    /// The result of a POST to the ingestion API.
+    /// True if the payload was ingested successfully; otherwise, false.
     /// </summary>
-    readonly struct IngestionResult
-    {
-        /// <summary>
-        /// True if the payload was ingested successfully; otherwise, false.
-        /// </summary>
-        public bool Succeeded { get; }
+    public bool Succeeded { get; }
         
-        /// <summary>
-        /// The status code returned from the ingestion endpoint.
-        /// </summary>
-        public HttpStatusCode StatusCode { get; }
+    /// <summary>
+    /// The status code returned from the ingestion endpoint.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
         
-        /// <summary>
-        /// The minimum level accepted by the API. This will be null when the ingestion attempt failed, and
-        /// when the server is accepting all events.
-        /// </summary>
-        public LogEventLevel? MinimumAcceptedLevel { get; }
+    /// <summary>
+    /// The minimum level accepted by the API. This will be null when the ingestion attempt failed, and
+    /// when the server is accepting all events.
+    /// </summary>
+    public LogEventLevel? MinimumAcceptedLevel { get; }
 
-        /// <summary>
-        /// Construct an <see cref="IngestionResult"/>.
-        /// </summary>
-        /// <param name="succeeded">True if the payload was ingested successfully; otherwise, false.</param>
-        /// <param name="statusCode">The status code returned from the ingestion endpoint.</param>
-        /// <param name="minimumAcceptedLevel">The minimum level accepted by the API. This will be null when the ingestion attempt failed, and
-        /// when the server is accepting all events.</param>
-        public IngestionResult(bool succeeded, HttpStatusCode statusCode, LogEventLevel? minimumAcceptedLevel)
-        {
-            Succeeded = succeeded;
-            StatusCode = statusCode;
-            MinimumAcceptedLevel = minimumAcceptedLevel;
-        }
+    /// <summary>
+    /// Construct an <see cref="IngestionResult"/>.
+    /// </summary>
+    /// <param name="succeeded">True if the payload was ingested successfully; otherwise, false.</param>
+    /// <param name="statusCode">The status code returned from the ingestion endpoint.</param>
+    /// <param name="minimumAcceptedLevel">The minimum level accepted by the API. This will be null when the ingestion attempt failed, and
+    /// when the server is accepting all events.</param>
+    public IngestionResult(bool succeeded, HttpStatusCode statusCode, LogEventLevel? minimumAcceptedLevel)
+    {
+        Succeeded = succeeded;
+        StatusCode = statusCode;
+        MinimumAcceptedLevel = minimumAcceptedLevel;
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Http/SeqIngestionApi.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Http/SeqIngestionApi.cs
@@ -18,57 +18,56 @@ using System.Threading.Tasks;
 using Serilog.Debugging;
 using Serilog.Events;
 
-namespace Serilog.Sinks.Seq.Http
+namespace Serilog.Sinks.Seq.Http;
+
+/// <summary>
+/// A substitutable interface type for the Seq HTTP ingestion API.
+/// </summary>
+/// <remarks>A class rather than an interface for convenience reasons (and because disposable interfaces are awful).</remarks>
+abstract class SeqIngestionApi : IDisposable
 {
     /// <summary>
-    /// A substitutable interface type for the Seq HTTP ingestion API.
+    /// The media type describing the original JSON-based payload format. Use is now discouraged. Remains here only
+    /// so that durable buffer files written by earlier versions of the sink can still be read and ingested.
     /// </summary>
-    /// <remarks>A class rather than an interface for convenience reasons (and because disposable interfaces are awful).</remarks>
-    abstract class SeqIngestionApi : IDisposable
+    public const string RawEventFormatMediaType = "application/json";
+        
+    /// <summary>
+    /// Media type for the modern CLEF payload format.
+    /// </summary>
+    public const string CompactLogEventFormatMediaType = "application/vnd.serilog.clef";
+        
+    /// <summary>
+    /// A valid but empty payload in the <see cref="CompactLogEventFormatMediaType"/> format.
+    /// </summary>
+    public const string EmptyClefPayload = "";
+
+    /// <summary>
+    /// Ingest <paramref name="clefPayload" />.
+    /// </summary>
+    /// <param name="clefPayload">Log events in CLEF format.</param>
+    /// <returns>The minimum level accepted by the Seq server (if any is specified).</returns>
+    /// <exception cref="LoggingFailedException">The events could not be ingested.</exception>
+    /// <exception cref="HttpRequestException">The ingestion request could not be sent.</exception>
+    public async Task<LogEventLevel?> IngestAsync(string clefPayload)
     {
-        /// <summary>
-        /// The media type describing the original JSON-based payload format. Use is now discouraged. Remains here only
-        /// so that durable buffer files written by earlier versions of the sink can still be read and ingested.
-        /// </summary>
-        public const string RawEventFormatMediaType = "application/json";
-        
-        /// <summary>
-        /// Media type for the modern CLEF payload format.
-        /// </summary>
-        public const string CompactLogEventFormatMediaType = "application/vnd.serilog.clef";
-        
-        /// <summary>
-        /// A valid but empty payload in the <see cref="CompactLogEventFormatMediaType"/> format.
-        /// </summary>
-        public const string EmptyClefPayload = "";
+        var result = await TryIngestAsync(clefPayload, CompactLogEventFormatMediaType);
 
-        /// <summary>
-        /// Ingest <paramref name="clefPayload" />.
-        /// </summary>
-        /// <param name="clefPayload">Log events in CLEF format.</param>
-        /// <returns>The minimum level accepted by the Seq server (if any is specified).</returns>
-        /// <exception cref="LoggingFailedException">The events could not be ingested.</exception>
-        /// <exception cref="HttpRequestException">The ingestion request could not be sent.</exception>
-        public async Task<LogEventLevel?> IngestAsync(string clefPayload)
-        {
-            var result = await TryIngestAsync(clefPayload, CompactLogEventFormatMediaType);
+        if (!result.Succeeded)
+            throw new LoggingFailedException($"Received failed result {result.StatusCode} when posting events to Seq.");
 
-            if (!result.Succeeded)
-                throw new LoggingFailedException($"Received failed result {result.StatusCode} when posting events to Seq.");
-
-            return result.MinimumAcceptedLevel;
-        }
-
-        /// <summary>
-        /// Attempt to ingest <paramref name="payload"/>.
-        /// </summary>
-        /// <param name="payload">The text-formatted payload to ingest.</param>
-        /// <param name="mediaType">The media type describing the payload.</param>
-        /// <returns>An <see cref="IngestionResult"/> with the response from the ingestion API.</returns>
-        /// <exception cref="HttpRequestException">The ingestion request could not be sent.</exception>
-        public abstract Task<IngestionResult> TryIngestAsync(string payload, string mediaType);
-        
-        /// <inheritdoc/>
-        public virtual void Dispose() { }
+        return result.MinimumAcceptedLevel;
     }
+
+    /// <summary>
+    /// Attempt to ingest <paramref name="payload"/>.
+    /// </summary>
+    /// <param name="payload">The text-formatted payload to ingest.</param>
+    /// <param name="mediaType">The media type describing the payload.</param>
+    /// <returns>An <see cref="IngestionResult"/> with the response from the ingestion API.</returns>
+    /// <exception cref="HttpRequestException">The ingestion request could not be sent.</exception>
+    public abstract Task<IngestionResult> TryIngestAsync(string payload, string mediaType);
+        
+    /// <inheritdoc/>
+    public virtual void Dispose() { }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/PortableTimer.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/PortableTimer.cs
@@ -17,93 +17,92 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Serilog.Sinks.Seq
+namespace Serilog.Sinks.Seq;
+
+sealed class PortableTimer : IDisposable
 {
-    sealed class PortableTimer : IDisposable
+    readonly object _stateLock = new();
+
+    readonly Func<CancellationToken, Task> _onTick;
+    readonly CancellationTokenSource _cancel = new();
+
+    readonly Timer _timer;
+
+    bool _running;
+    bool _disposed;
+
+    public PortableTimer(Func<CancellationToken, Task> onTick)
     {
-        readonly object _stateLock = new();
+        _onTick = onTick ?? throw new ArgumentNullException(nameof(onTick));
+        _timer = new Timer(_ => OnTick(), null, Timeout.Infinite, Timeout.Infinite);
+    }
 
-        readonly Func<CancellationToken, Task> _onTick;
-        readonly CancellationTokenSource _cancel = new();
+    public void Start(TimeSpan interval)
+    {
+        if (interval < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(interval));
 
-        readonly Timer _timer;
-
-        bool _running;
-        bool _disposed;
-
-        public PortableTimer(Func<CancellationToken, Task> onTick)
+        lock (_stateLock)
         {
-            _onTick = onTick ?? throw new ArgumentNullException(nameof(onTick));
-            _timer = new Timer(_ => OnTick(), null, Timeout.Infinite, Timeout.Infinite);
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(PortableTimer));
+
+            _timer.Change(interval, Timeout.InfiniteTimeSpan);
         }
+    }
 
-        public void Start(TimeSpan interval)
+    async void OnTick()
+    {
+        try
         {
-            if (interval < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(interval));
-
             lock (_stateLock)
             {
-                if (_disposed)
-                    throw new ObjectDisposedException(nameof(PortableTimer));
-
-                _timer.Change(interval, Timeout.InfiniteTimeSpan);
-            }
-        }
-
-        async void OnTick()
-        {
-            try
-            {
-                lock (_stateLock)
+                if (_disposed || _running)
                 {
-                    if (_disposed || _running)
-                    {
-                        // Timer callbacks may be overlapped; if the sink is still shipping logs when the next interval
-                        // begins, skip this interval to avoid piling up threads.
-                        return;
-                    }
-
-                    _running = true;
-                }
-
-                if (!_cancel.Token.IsCancellationRequested)
-                {
-                    await _onTick(_cancel.Token);
-                }
-            }
-            catch (OperationCanceledException tcx)
-            {
-                SelfLog.WriteLine("The timer was canceled during invocation: {0}", tcx);
-            }
-            finally
-            {
-                lock (_stateLock)
-                {
-                    _running = false;
-                    Monitor.PulseAll(_stateLock);
-                }
-            }
-        }
-
-        public void Dispose()
-        {
-            _cancel.Cancel();
-
-            lock (_stateLock)
-            {
-                if (_disposed)
-                {
+                    // Timer callbacks may be overlapped; if the sink is still shipping logs when the next interval
+                    // begins, skip this interval to avoid piling up threads.
                     return;
                 }
 
-                while (_running)
-                {
-                    Monitor.Wait(_stateLock);
-                }
-
-                _timer.Dispose();
-                _disposed = true;
+                _running = true;
             }
+
+            if (!_cancel.Token.IsCancellationRequested)
+            {
+                await _onTick(_cancel.Token);
+            }
+        }
+        catch (OperationCanceledException tcx)
+        {
+            SelfLog.WriteLine("The timer was canceled during invocation: {0}", tcx);
+        }
+        finally
+        {
+            lock (_stateLock)
+            {
+                _running = false;
+                Monitor.PulseAll(_stateLock);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cancel.Cancel();
+
+        lock (_stateLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            while (_running)
+            {
+                Monitor.Wait(_stateLock);
+            }
+
+            _timer.Dispose();
+            _disposed = true;
         }
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/Audit/SeqAuditSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Audit/SeqAuditSinkTests.cs
@@ -7,74 +7,73 @@ using Serilog.Sinks.Seq.Audit;
 using Serilog.Sinks.Seq.Tests.Support;
 using Xunit;
 
-namespace Serilog.Sinks.Seq.Tests.Audit
+namespace Serilog.Sinks.Seq.Tests.Audit;
+
+public class SeqAuditSinkTests
 {
-    public class SeqAuditSinkTests
+    [Fact]
+    public void EarlyCommunicationErrorsPropagateToCallerWhenAuditing()
     {
-        [Fact]
-        public void EarlyCommunicationErrorsPropagateToCallerWhenAuditing()
-        {
-            using var logger = new LoggerConfiguration()
-                .AuditTo.Seq("https://example.tld")
-                .CreateLogger();
-            var ex = Assert.Throws<AggregateException>(() => logger.Information("This is an audit event"));
-            var baseException = ex.GetBaseException();
-            Assert.IsType<HttpRequestException>(baseException);
-        }
+        using var logger = new LoggerConfiguration()
+            .AuditTo.Seq("https://example.tld")
+            .CreateLogger();
+        var ex = Assert.Throws<AggregateException>(() => logger.Information("This is an audit event"));
+        var baseException = ex.GetBaseException();
+        Assert.IsType<HttpRequestException>(baseException);
+    }
 
-        [Fact] // This test requires an outbound connection in order to execute properly.
-        public void RemoteCommunicationErrorsPropagateToCallerWhenAuditing()
-        {
-            using var logger = new LoggerConfiguration()
-                .AuditTo.Seq("https://datalust.co/error/404")
-                .CreateLogger();
+    [Fact] // This test requires an outbound connection in order to execute properly.
+    public void RemoteCommunicationErrorsPropagateToCallerWhenAuditing()
+    {
+        using var logger = new LoggerConfiguration()
+            .AuditTo.Seq("https://datalust.co/error/404")
+            .CreateLogger();
             
-            var ex = Assert.Throws<AggregateException>(() => logger.Information("This is an audit event"));
+        var ex = Assert.Throws<AggregateException>(() => logger.Information("This is an audit event"));
             
-            var baseException = ex.GetBaseException();
-            Assert.IsType<LoggingFailedException>(baseException);
-        }
+        var baseException = ex.GetBaseException();
+        Assert.IsType<LoggingFailedException>(baseException);
+    }
 
-        [Fact]
-        public void AuditSinkDisposesIngestionApi()
-        {
-            var api = new TestIngestionApi();
-            var sink = new SeqAuditSink(api);
-            Assert.False(api.IsDisposed);
+    [Fact]
+    public void AuditSinkDisposesIngestionApi()
+    {
+        var api = new TestIngestionApi();
+        var sink = new SeqAuditSink(api);
+        Assert.False(api.IsDisposed);
             
-            sink.Dispose();
+        sink.Dispose();
             
-            Assert.True(api.IsDisposed);
-        }
+        Assert.True(api.IsDisposed);
+    }
 
-        [Fact]
-        public async Task AuditSinkEmitsIndividualEvents()
-        {
-            LogEvent evt1 = Some.InformationEvent("first"), evt2 = Some.InformationEvent("second");
+    [Fact]
+    public async Task AuditSinkEmitsIndividualEvents()
+    {
+        LogEvent evt1 = Some.InformationEvent("first"), evt2 = Some.InformationEvent("second");
             
-            var api = new TestIngestionApi();
-            var sink = new SeqAuditSink(api);
+        var api = new TestIngestionApi();
+        var sink = new SeqAuditSink(api);
             
-            sink.Emit(evt1);
-            sink.Emit(evt2);
+        sink.Emit(evt1);
+        sink.Emit(evt2);
 
-            var first = await api.GetPayloadAsync();
-            Assert.Contains("first", first.Payload);
+        var first = await api.GetPayloadAsync();
+        Assert.Contains("first", first.Payload);
             
-            var second = await api.GetPayloadAsync();
-            Assert.Contains("second", second.Payload);
-        }
+        var second = await api.GetPayloadAsync();
+        Assert.Contains("second", second.Payload);
+    }
 
-        [Fact]
-        public void AuditSinkPropagatesExceptions()
-        {
-            var expected = new Exception("Test");
-            var api = new TestIngestionApi(_ => throw expected);
-            var sink = new SeqAuditSink(api);
+    [Fact]
+    public void AuditSinkPropagatesExceptions()
+    {
+        var expected = new Exception("Test");
+        var api = new TestIngestionApi(_ => throw expected);
+        var sink = new SeqAuditSink(api);
             
-            var thrown = Assert.Throws<AggregateException>(() => sink.Emit(Some.InformationEvent()));
+        var thrown = Assert.Throws<AggregateException>(() => sink.Emit(Some.InformationEvent()));
             
-            Assert.Equal(expected, thrown.GetBaseException());
-        }
+        Assert.Equal(expected, thrown.GetBaseException());
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/Batched/BatchedSeqSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Batched/BatchedSeqSinkTests.cs
@@ -7,51 +7,50 @@ using Serilog.Sinks.Seq.Http;
 using Serilog.Sinks.Seq.Tests.Support;
 using Xunit;
 
-namespace Serilog.Sinks.Seq.Tests.Batched
+namespace Serilog.Sinks.Seq.Tests.Batched;
+
+public class BatchedSeqSinkTests
 {
-    public class BatchedSeqSinkTests
+    [Fact]
+    public void BatchedSinkDisposesIngestionApi()
     {
-        [Fact]
-        public void BatchedSinkDisposesIngestionApi()
-        {
-            var api = new TestIngestionApi();
-            var sink = new BatchedSeqSink(api, null, new ControlledLevelSwitch());
-            Assert.False(api.IsDisposed);
+        var api = new TestIngestionApi();
+        var sink = new BatchedSeqSink(api, null, new ControlledLevelSwitch());
+        Assert.False(api.IsDisposed);
             
-            sink.Dispose();
+        sink.Dispose();
             
-            Assert.True(api.IsDisposed);
-        }
+        Assert.True(api.IsDisposed);
+    }
         
-        [Fact]
-        public async Task EventsAreFormattedIntoPayloads()
+    [Fact]
+    public async Task EventsAreFormattedIntoPayloads()
+    {
+        var api = new TestIngestionApi();
+        var sink = new BatchedSeqSink(api, null, new ControlledLevelSwitch());
+
+        await sink.EmitBatchAsync(new[]
         {
-            var api = new TestIngestionApi();
-            var sink = new BatchedSeqSink(api, null, new ControlledLevelSwitch());
+            Some.InformationEvent("first"),
+            Some.InformationEvent("second")
+        });
 
-            await sink.EmitBatchAsync(new[]
-            {
-                Some.InformationEvent("first"),
-                Some.InformationEvent("second")
-            });
+        var emitted = await api.GetPayloadAsync();
 
-            var emitted = await api.GetPayloadAsync();
+        Assert.Contains("first", emitted.Payload);
+        Assert.Contains("second", emitted.Payload);
+    }
 
-            Assert.Contains("first", emitted.Payload);
-            Assert.Contains("second", emitted.Payload);
-        }
+    [Fact]
+    public async Task MinimumLevelIsControlled()
+    {
+        const LogEventLevel originalLevel = LogEventLevel.Debug, newLevel = LogEventLevel.Error;
+        var levelSwitch = new LoggingLevelSwitch(originalLevel);
+        var api = new TestIngestionApi(_ => Task.FromResult(new IngestionResult(true, HttpStatusCode.Accepted, newLevel)));
+        var sink = new BatchedSeqSink(api, null, new ControlledLevelSwitch(levelSwitch));
 
-        [Fact]
-        public async Task MinimumLevelIsControlled()
-        {
-            const LogEventLevel originalLevel = LogEventLevel.Debug, newLevel = LogEventLevel.Error;
-            var levelSwitch = new LoggingLevelSwitch(originalLevel);
-            var api = new TestIngestionApi(_ => Task.FromResult(new IngestionResult(true, HttpStatusCode.Accepted, newLevel)));
-            var sink = new BatchedSeqSink(api, null, new ControlledLevelSwitch(levelSwitch));
-
-            await sink.EmitBatchAsync(new[] { Some.InformationEvent() });
+        await sink.EmitBatchAsync(new[] { Some.InformationEvent() });
             
-            Assert.Equal(newLevel, levelSwitch.MinimumLevel);
-        }
+        Assert.Equal(newLevel, levelSwitch.MinimumLevel);
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
@@ -2,57 +2,56 @@
 using Serilog.Sinks.Seq.Tests.Support;
 using Xunit;
 
-namespace Serilog.Sinks.Seq.Tests
+namespace Serilog.Sinks.Seq.Tests;
+
+public class ConstrainedBufferedFormatterTests
 {
-    public class ConstrainedBufferedFormatterTests
+    [Fact]
+    public void EventsAreFormattedIntoCompactJsonPayloads()
     {
-        [Fact]
-        public void EventsAreFormattedIntoCompactJsonPayloads()
-        {
-            var evt = Some.LogEvent("Hello, {Name}!", "Alice");
-            var formatter = new ConstrainedBufferedFormatter(null);
-            var json = new StringWriter();
-            formatter.Format(evt, json);
-            Assert.Contains("Name\":\"Alice", json.ToString());
-        }
+        var evt = Some.LogEvent("Hello, {Name}!", "Alice");
+        var formatter = new ConstrainedBufferedFormatter(null);
+        var json = new StringWriter();
+        formatter.Format(evt, json);
+        Assert.Contains("Name\":\"Alice", json.ToString());
+    }
 
-        [Fact]
-        public void PlaceholdersAreLoggedWhenCompactJsonRenderingFails()
-        {
-            var evt = Some.LogEvent(new NastyException(), "Hello, {Name}!", "Alice");
-            var formatter = new ConstrainedBufferedFormatter(null);
-            var json = new StringWriter();
-            formatter.Format(evt, json);
-            var jsonString = json.ToString();
-            Assert.Contains("could not be formatted", jsonString);
-            Assert.Contains("OriginalMessageTemplate\":\"Hello, ", jsonString);
-        }
+    [Fact]
+    public void PlaceholdersAreLoggedWhenCompactJsonRenderingFails()
+    {
+        var evt = Some.LogEvent(new NastyException(), "Hello, {Name}!", "Alice");
+        var formatter = new ConstrainedBufferedFormatter(null);
+        var json = new StringWriter();
+        formatter.Format(evt, json);
+        var jsonString = json.ToString();
+        Assert.Contains("could not be formatted", jsonString);
+        Assert.Contains("OriginalMessageTemplate\":\"Hello, ", jsonString);
+    }
         
-        [Fact]
-        public void PlaceholdersAreLoggedWhenTheEventSizeLimitIsExceeded()
-        {
-            var evt = Some.LogEvent("Hello, {Name}!", new string('a', 10000));
-            var formatter = new ConstrainedBufferedFormatter(2000);
-            var json = new StringWriter();
-            formatter.Format(evt, json);
-            var jsonString = json.ToString();
-            Assert.Contains("exceeds the body size limit", jsonString);
-            Assert.Contains("\"EventBodySample\"", jsonString);
-            Assert.Contains("aaaaa", jsonString);
-        }
+    [Fact]
+    public void PlaceholdersAreLoggedWhenTheEventSizeLimitIsExceeded()
+    {
+        var evt = Some.LogEvent("Hello, {Name}!", new string('a', 10000));
+        var formatter = new ConstrainedBufferedFormatter(2000);
+        var json = new StringWriter();
+        formatter.Format(evt, json);
+        var jsonString = json.ToString();
+        Assert.Contains("exceeds the body size limit", jsonString);
+        Assert.Contains("\"EventBodySample\"", jsonString);
+        Assert.Contains("aaaaa", jsonString);
+    }
 
-        [Theory]
-        [InlineData(0, 512)]
-        [InlineData(1, 512)]
-        [InlineData(512, 512)]
-        [InlineData(1000, 512)]
-        [InlineData(5000, 1476)]
-        [InlineData(10000, 3976)]
-        [InlineData(130048, 64000)]
-        public void PlaceholderSampleSizeIsComputedFromEventBodyLimitBytes(long eventBodyLimitBytes, long expectedSampleSize)
-        {
-            var actual = ConstrainedBufferedFormatter.GetOversizeEventSampleLength(eventBodyLimitBytes);
-            Assert.Equal(expectedSampleSize, actual);
-        }
+    [Theory]
+    [InlineData(0, 512)]
+    [InlineData(1, 512)]
+    [InlineData(512, 512)]
+    [InlineData(1000, 512)]
+    [InlineData(5000, 1476)]
+    [InlineData(10000, 3976)]
+    [InlineData(130048, 64000)]
+    public void PlaceholderSampleSizeIsComputedFromEventBodyLimitBytes(long eventBodyLimitBytes, long expectedSampleSize)
+    {
+        var actual = ConstrainedBufferedFormatter.GetOversizeEventSampleLength(eventBodyLimitBytes);
+        Assert.Equal(expectedSampleSize, actual);
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/ControlledLevelSwitchTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/ControlledLevelSwitchTests.cs
@@ -5,87 +5,86 @@ using Xunit;
 
 // ReSharper disable RedundantArgumentDefaultValue
 
-namespace Serilog.Sinks.Seq.Tests
+namespace Serilog.Sinks.Seq.Tests;
+
+public class ControlledLevelSwitchTests
 {
-    public class ControlledLevelSwitchTests
+    [Fact]
+    public void WhenTheServerSendsALevelTheSwitchIsAdjusted()
     {
-        [Fact]
-        public void WhenTheServerSendsALevelTheSwitchIsAdjusted()
-        {
-            var lls = new LoggingLevelSwitch(LogEventLevel.Warning);
-            var cls = new ControlledLevelSwitch(lls);
-            cls.Update(LogEventLevel.Debug);
-            Assert.Equal(LogEventLevel.Debug, lls.MinimumLevel);
-        }
+        var lls = new LoggingLevelSwitch(LogEventLevel.Warning);
+        var cls = new ControlledLevelSwitch(lls);
+        cls.Update(LogEventLevel.Debug);
+        Assert.Equal(LogEventLevel.Debug, lls.MinimumLevel);
+    }
 
-        [Fact]
-        public void WhenTheServerSendsNoLevelTheSwitchIsNotInitiallyAdjusted()
-        {
-            var lls = new LoggingLevelSwitch(LogEventLevel.Fatal);
-            var cls = new ControlledLevelSwitch(lls);
-            cls.Update(null);
-            Assert.Equal(LogEventLevel.Fatal, lls.MinimumLevel);
-        }
+    [Fact]
+    public void WhenTheServerSendsNoLevelTheSwitchIsNotInitiallyAdjusted()
+    {
+        var lls = new LoggingLevelSwitch(LogEventLevel.Fatal);
+        var cls = new ControlledLevelSwitch(lls);
+        cls.Update(null);
+        Assert.Equal(LogEventLevel.Fatal, lls.MinimumLevel);
+    }
 
-        [Fact]
-        public void WhenTheServerSendsNoLevelTheSwitchIsResetIfPreviouslyAdjusted()
-        {
-            var lls = new LoggingLevelSwitch(LogEventLevel.Warning);
-            var cls = new ControlledLevelSwitch(lls);
-            cls.Update(LogEventLevel.Information);
-            cls.Update(null);
-            Assert.Equal(LogEventLevel.Warning, lls.MinimumLevel);
-        }
+    [Fact]
+    public void WhenTheServerSendsNoLevelTheSwitchIsResetIfPreviouslyAdjusted()
+    {
+        var lls = new LoggingLevelSwitch(LogEventLevel.Warning);
+        var cls = new ControlledLevelSwitch(lls);
+        cls.Update(LogEventLevel.Information);
+        cls.Update(null);
+        Assert.Equal(LogEventLevel.Warning, lls.MinimumLevel);
+    }
 
-        [Fact]
-        public void WithNoSwitchToControlAllEventsAreIncluded()
-        {
-            var cls = new ControlledLevelSwitch(null);
-            Assert.True(cls.IsIncluded(Some.DebugEvent()));
-        }
+    [Fact]
+    public void WithNoSwitchToControlAllEventsAreIncluded()
+    {
+        var cls = new ControlledLevelSwitch(null);
+        Assert.True(cls.IsIncluded(Some.DebugEvent()));
+    }
 
-        [Fact]
-        public void WithNoSwitchToControlEventsAreStillFiltered()
-        {
-            var cls = new ControlledLevelSwitch(null);
-            cls.Update(LogEventLevel.Warning);
-            Assert.True(cls.IsIncluded(Some.ErrorEvent()));
-            Assert.False(cls.IsIncluded(Some.InformationEvent()));
-        }
+    [Fact]
+    public void WithNoSwitchToControlEventsAreStillFiltered()
+    {
+        var cls = new ControlledLevelSwitch(null);
+        cls.Update(LogEventLevel.Warning);
+        Assert.True(cls.IsIncluded(Some.ErrorEvent()));
+        Assert.False(cls.IsIncluded(Some.InformationEvent()));
+    }
 
-        [Fact]
-        public void WithNoSwitchToControlAllEventsAreIncludedAfterReset()
-        {
-            var cls = new ControlledLevelSwitch(null);
-            cls.Update(LogEventLevel.Warning);
-            cls.Update(null);
-            Assert.True(cls.IsIncluded(Some.DebugEvent()));
-        }
+    [Fact]
+    public void WithNoSwitchToControlAllEventsAreIncludedAfterReset()
+    {
+        var cls = new ControlledLevelSwitch(null);
+        cls.Update(LogEventLevel.Warning);
+        cls.Update(null);
+        Assert.True(cls.IsIncluded(Some.DebugEvent()));
+    }
 
-        [Fact]
-        public void WhenControllingASwitchTheControllerIsActive()
-        {
-            var cls = new ControlledLevelSwitch(new LoggingLevelSwitch());
-            Assert.True(cls.IsActive);
-        }
+    [Fact]
+    public void WhenControllingASwitchTheControllerIsActive()
+    {
+        var cls = new ControlledLevelSwitch(new LoggingLevelSwitch());
+        Assert.True(cls.IsActive);
+    }
 
-        [Fact]
-        public void WhenNotControllingASwitchTheControllerIsNotActive()
-        {
-            var cls = new ControlledLevelSwitch();
-            Assert.False(cls.IsActive);
-        }
+    [Fact]
+    public void WhenNotControllingASwitchTheControllerIsNotActive()
+    {
+        var cls = new ControlledLevelSwitch();
+        Assert.False(cls.IsActive);
+    }
 
-        [Fact]
-        public void AfterServerControlTheControllerIsAlwaysActive()
-        {
-            var cls = new ControlledLevelSwitch();
+    [Fact]
+    public void AfterServerControlTheControllerIsAlwaysActive()
+    {
+        var cls = new ControlledLevelSwitch();
 
-            cls.Update(LogEventLevel.Information);
-            Assert.True(cls.IsActive);
+        cls.Update(LogEventLevel.Information);
+        Assert.True(cls.IsActive);
 
-            cls.Update(null);
-            Assert.True(cls.IsActive);
-        }
+        cls.Update(null);
+        Assert.True(cls.IsActive);
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/Durable/BookmarkFileTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Durable/BookmarkFileTests.cs
@@ -2,22 +2,21 @@
 using Serilog.Sinks.Seq.Tests.Support;
 using Xunit;
 
-namespace Serilog.Sinks.Seq.Tests.Durable
+namespace Serilog.Sinks.Seq.Tests.Durable;
+
+public class BookmarkFileTests
 {
-    public class BookmarkFileTests
+    [Fact]
+    public void BookmarkPersistenceCanBeRoundTripped()
     {
-        [Fact]
-        public void BookmarkPersistenceCanBeRoundTripped()
-        {
-            using var tmp = new TempFolder();
-            var position = new FileSetPosition(1234, Some.String());
+        using var tmp = new TempFolder();
+        var position = new FileSetPosition(1234, Some.String());
 
-            var bookmark = new BookmarkFile(tmp.AllocateFilename("bookmark"));
-            bookmark.WriteBookmark(position);
+        var bookmark = new BookmarkFile(tmp.AllocateFilename("bookmark"));
+        bookmark.WriteBookmark(position);
 
-            var read = bookmark.TryReadBookmark();
-            Assert.Equal(position.NextLineStart, read.NextLineStart);
-            Assert.Equal(position.File, read.File);
-        }
+        var read = bookmark.TryReadBookmark();
+        Assert.Equal(position.NextLineStart, read.NextLineStart);
+        Assert.Equal(position.File, read.File);
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/Durable/PayloadReaderTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Durable/PayloadReaderTests.cs
@@ -8,63 +8,62 @@ using Serilog.Sinks.Seq.Tests.Support;
 using Xunit;
 using IOFile = System.IO.File;
 
-namespace Serilog.Sinks.Seq.Tests.Durable
+namespace Serilog.Sinks.Seq.Tests.Durable;
+
+public class PayloadReaderTests
 {
-    public class PayloadReaderTests
+    [Fact]
+    public void ReadsEventsFromBufferFiles()
     {
-        [Fact]
-        public void ReadsEventsFromBufferFiles()
+        using var tmp = new TempFolder();
+        var fn = tmp.AllocateFilename("clef");
+        var lines = IOFile.ReadAllText(Path.Combine("Resources", "ThreeBufferedEvents.clef.txt"), Encoding.UTF8).Split(new [] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
+        using (var f = IOFile.Create(fn))
+        using (var fw = new StreamWriter(f, Encoding.UTF8))
         {
-            using var tmp = new TempFolder();
-            var fn = tmp.AllocateFilename("clef");
-            var lines = IOFile.ReadAllText(Path.Combine("Resources", "ThreeBufferedEvents.clef.txt"), Encoding.UTF8).Split(new [] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
-            using (var f = IOFile.Create(fn))
-            using (var fw = new StreamWriter(f, Encoding.UTF8))
+            foreach (var line in lines)
             {
-                foreach (var line in lines)
-                {
-                    fw.WriteLine(line);
-                }
+                fw.WriteLine(line);
             }
-            var position = new FileSetPosition(0, fn);
-            var count = 0;
-            PayloadReader.ReadPayload(1000, null, ref position, ref count, out var mimeType);
-                
-            Assert.Equal(SeqIngestionApi.CompactLogEventFormatMediaType, mimeType);
-
-            Assert.Equal(3, count);
-            Assert.Equal(465 + 3 * (Environment.NewLine.Length - 1), position.NextLineStart);
-            Assert.Equal(fn, position.File);
         }
+        var position = new FileSetPosition(0, fn);
+        var count = 0;
+        PayloadReader.ReadPayload(1000, null, ref position, ref count, out var mimeType);
+                
+        Assert.Equal(SeqIngestionApi.CompactLogEventFormatMediaType, mimeType);
 
-        [Fact]
-        public void ReadsEventsFromRawBufferFiles()
+        Assert.Equal(3, count);
+        Assert.Equal(465 + 3 * (Environment.NewLine.Length - 1), position.NextLineStart);
+        Assert.Equal(fn, position.File);
+    }
+
+    [Fact]
+    public void ReadsEventsFromRawBufferFiles()
+    {
+        using var tmp = new TempFolder();
+        var fn = tmp.AllocateFilename("json");
+        var lines = IOFile.ReadAllText(Path.Combine("Resources", "ThreeBufferedEvents.json.txt"), Encoding.UTF8).Split(new [] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
+        using (var f = IOFile.Create(fn))
+        using (var fw = new StreamWriter(f, Encoding.UTF8))
         {
-            using var tmp = new TempFolder();
-            var fn = tmp.AllocateFilename("json");
-            var lines = IOFile.ReadAllText(Path.Combine("Resources", "ThreeBufferedEvents.json.txt"), Encoding.UTF8).Split(new [] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
-            using (var f = IOFile.Create(fn))
-            using (var fw = new StreamWriter(f, Encoding.UTF8))
+            foreach (var line in lines)
             {
-                foreach (var line in lines)
-                {
-                    fw.WriteLine(line);
-                }
+                fw.WriteLine(line);
             }
-            var position = new FileSetPosition(0, fn);
-            var count = 0;
-            var payload = PayloadReader.ReadPayload(1000, null, ref position, ref count, out var mimeType);
-                
-            Assert.Equal(SeqIngestionApi.RawEventFormatMediaType, mimeType);
-
-            Assert.Equal(3, count);
-            Assert.Equal(576 + 3 * (Environment.NewLine.Length - 1), position.NextLineStart);
-            Assert.Equal(fn, position.File);
-
-            var data = JsonConvert.DeserializeObject<dynamic>(payload)!;
-            var events = data["Events"];
-            Assert.NotNull(events);
-            Assert.Equal(3, events.Count);
         }
+        var position = new FileSetPosition(0, fn);
+        var count = 0;
+        var payload = PayloadReader.ReadPayload(1000, null, ref position, ref count, out var mimeType);
+                
+        Assert.Equal(SeqIngestionApi.RawEventFormatMediaType, mimeType);
+
+        Assert.Equal(3, count);
+        Assert.Equal(576 + 3 * (Environment.NewLine.Length - 1), position.NextLineStart);
+        Assert.Equal(fn, position.File);
+
+        var data = JsonConvert.DeserializeObject<dynamic>(payload)!;
+        var events = data["Events"];
+        Assert.NotNull(events);
+        Assert.Equal(3, events.Count);
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/Http/SeqIngestionApiClientTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Http/SeqIngestionApiClientTests.cs
@@ -2,36 +2,35 @@
 using Serilog.Sinks.Seq.Http;
 using Xunit;
 
-namespace Serilog.Sinks.Seq.Tests.Http
-{
-    public class SeqIngestionApiClientTests
-    {
-        [Theory]
-        [InlineData("https://example.com", "https://example.com/")]
-        [InlineData("https://example.com/", "https://example.com/")]
-        [InlineData("https://example.com:7777", "https://example.com:7777/")]
-        [InlineData("https://example.com/test", "https://example.com/test/")]
-        [InlineData("https://example.com/test/", "https://example.com/test/")]
-        public void ServerBaseAddressesAreNormalized(string url, string expected)
-        {
-            var normalized = SeqIngestionApiClient.NormalizeServerBaseAddress(url);
-            Assert.Equal(expected, normalized);
-        }
+namespace Serilog.Sinks.Seq.Tests.Http;
 
-        [Fact]
-        public void MinimumAcceptedLevelIsExtractedWhenPresent()
-        {
-            const string response = @"{""MinimumLevelAccepted"":""Warning""}";
-            var extracted = SeqIngestionApiClient.ReadIngestionResult(response);
-            Assert.Equal(LogEventLevel.Warning, extracted);
-        }
+public class SeqIngestionApiClientTests
+{
+    [Theory]
+    [InlineData("https://example.com", "https://example.com/")]
+    [InlineData("https://example.com/", "https://example.com/")]
+    [InlineData("https://example.com:7777", "https://example.com:7777/")]
+    [InlineData("https://example.com/test", "https://example.com/test/")]
+    [InlineData("https://example.com/test/", "https://example.com/test/")]
+    public void ServerBaseAddressesAreNormalized(string url, string expected)
+    {
+        var normalized = SeqIngestionApiClient.NormalizeServerBaseAddress(url);
+        Assert.Equal(expected, normalized);
+    }
+
+    [Fact]
+    public void MinimumAcceptedLevelIsExtractedWhenPresent()
+    {
+        const string response = @"{""MinimumLevelAccepted"":""Warning""}";
+        var extracted = SeqIngestionApiClient.ReadIngestionResult(response);
+        Assert.Equal(LogEventLevel.Warning, extracted);
+    }
         
-        [Fact]
-        public void MinimumAcceptedLevelIsIgnoredWhenMissing()
-        {
-            const string response = @"{}";
-            var extracted = SeqIngestionApiClient.ReadIngestionResult(response);
-            Assert.Null(extracted);
-        }
+    [Fact]
+    public void MinimumAcceptedLevelIsIgnoredWhenMissing()
+    {
+        const string response = @"{}";
+        var extracted = SeqIngestionApiClient.ReadIngestionResult(response);
+        Assert.Null(extracted);
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/Serilog.Sinks.Seq.Tests.csproj
+++ b/test/Serilog.Sinks.Seq.Tests/Serilog.Sinks.Seq.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net4.8;netcoreapp3.1;net7.0</TargetFrameworks>
+    <TargetFrameworks>net4.8;net7.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Seq.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -10,11 +10,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);ASYNC_DISPOSE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
     <DefineConstants>$(DefineConstants);ASYNC_DISPOSE</DefineConstants>
   </PropertyGroup>
   
@@ -32,18 +28,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net4.8' ">
     <Reference Include="System.Net.Http" />
-    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="7.0.0" />
   </ItemGroup>
   
 </Project>

--- a/test/Serilog.Sinks.Seq.Tests/Support/IngestionPayload.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Support/IngestionPayload.cs
@@ -1,15 +1,14 @@
-﻿namespace Serilog.Sinks.Seq.Tests.Support
+﻿namespace Serilog.Sinks.Seq.Tests.Support;
+
+class IngestionPayload
 {
-    class IngestionPayload
+    public IngestionPayload(string payload, string mediaType)
     {
-        public IngestionPayload(string payload, string mediaType)
-        {
-            Payload = payload;
-            MediaType = mediaType;
-        }
-
-        public string Payload { get; }
-        public string MediaType { get; }
-
+        Payload = payload;
+        MediaType = mediaType;
     }
+
+    public string Payload { get; }
+    public string MediaType { get; }
+
 }

--- a/test/Serilog.Sinks.Seq.Tests/Support/NastyException.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Support/NastyException.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 
-namespace Serilog.Sinks.Seq.Tests.Support
+namespace Serilog.Sinks.Seq.Tests.Support;
+
+public class NastyException : Exception
 {
-    public class NastyException : Exception
+    public override string ToString()
     {
-        public override string ToString()
-        {
-            throw new InvalidOperationException("Can't ToString() a NastyException!");
-        }
+        throw new InvalidOperationException("Can't ToString() a NastyException!");
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/Support/Some.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Support/Some.cs
@@ -3,51 +3,50 @@ using System.Collections.Generic;
 using Serilog.Events;
 using Xunit.Sdk;
 
-namespace Serilog.Sinks.Seq.Tests.Support
+namespace Serilog.Sinks.Seq.Tests.Support;
+
+static class Some
 {
-    static class Some
+    public static LogEvent LogEvent(string messageTemplate, params object[] propertyValues)
     {
-        public static LogEvent LogEvent(string messageTemplate, params object[] propertyValues)
-        {
-            return LogEvent(null, messageTemplate, propertyValues);
-        }
+        return LogEvent(null, messageTemplate, propertyValues);
+    }
 
-        public static LogEvent LogEvent(Exception? exception, string messageTemplate, params object[] propertyValues)
-        {
-            return LogEvent(LogEventLevel.Information, exception, messageTemplate, propertyValues);
-        }
+    public static LogEvent LogEvent(Exception? exception, string messageTemplate, params object[] propertyValues)
+    {
+        return LogEvent(LogEventLevel.Information, exception, messageTemplate, propertyValues);
+    }
 
-        // ReSharper disable once MemberCanBePrivate.Global
-        public static LogEvent LogEvent(LogEventLevel level, Exception? exception, string messageTemplate, params object[] propertyValues)
-        {
-            var log = new LoggerConfiguration().CreateLogger();
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static LogEvent LogEvent(LogEventLevel level, Exception? exception, string messageTemplate, params object[] propertyValues)
+    {
+        var log = new LoggerConfiguration().CreateLogger();
 #pragma warning disable Serilog004 // Constant MessageTemplate verifier
-            if (!log.BindMessageTemplate(messageTemplate, propertyValues, out var template, out var properties))
+        if (!log.BindMessageTemplate(messageTemplate, propertyValues, out var template, out var properties))
 #pragma warning restore Serilog004 // Constant MessageTemplate verifier
-            {
-                throw new XunitException("Template could not be bound.");
-            }
-            return new LogEvent(DateTimeOffset.Now, level, exception, template, properties);
-        }
-
-        public static LogEvent DebugEvent()
         {
-            return LogEvent(LogEventLevel.Debug, null, "Debug event");
+            throw new XunitException("Template could not be bound.");
         }
+        return new LogEvent(DateTimeOffset.Now, level, exception, template, properties);
+    }
 
-        public static LogEvent InformationEvent(string? messageTemplate = null)
-        {
-            return LogEvent(LogEventLevel.Information, null, messageTemplate ?? "Information event");
-        }
+    public static LogEvent DebugEvent()
+    {
+        return LogEvent(LogEventLevel.Debug, null, "Debug event");
+    }
 
-        public static LogEvent ErrorEvent()
-        {
-            return LogEvent(LogEventLevel.Error, null, "Error event");
-        }
+    public static LogEvent InformationEvent(string? messageTemplate = null)
+    {
+        return LogEvent(LogEventLevel.Information, null, messageTemplate ?? "Information event");
+    }
 
-        public static string String()
-        {
-            return Guid.NewGuid().ToString("n");
-        }
+    public static LogEvent ErrorEvent()
+    {
+        return LogEvent(LogEventLevel.Error, null, "Error event");
+    }
+
+    public static string String()
+    {
+        return Guid.NewGuid().ToString("n");
     }
 }

--- a/test/Serilog.Sinks.Seq.Tests/Support/TempFolder.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Support/TempFolder.cs
@@ -3,43 +3,42 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 
-namespace Serilog.Sinks.Seq.Tests.Support
+namespace Serilog.Sinks.Seq.Tests.Support;
+
+class TempFolder : IDisposable
 {
-    class TempFolder : IDisposable
+    static readonly Guid Session = Guid.NewGuid();
+
+    readonly string _tempFolder;
+
+    public TempFolder([CallerMemberName] string? name = null)
     {
-        static readonly Guid Session = Guid.NewGuid();
+        _tempFolder = System.IO.Path.Combine(
+            Environment.GetEnvironmentVariable("TMP") ?? Environment.GetEnvironmentVariable("TMPDIR") ?? "/tmp",
+            "Serilog.Sinks.Seq.Tests",
+            Session.ToString("n"),
+            name ?? Guid.NewGuid().ToString("n"));
 
-        readonly string _tempFolder;
+        Directory.CreateDirectory(_tempFolder);
+    }
 
-        public TempFolder([CallerMemberName] string? name = null)
+    public string Path => _tempFolder;
+
+    public void Dispose()
+    {
+        try
         {
-            _tempFolder = System.IO.Path.Combine(
-                Environment.GetEnvironmentVariable("TMP") ?? Environment.GetEnvironmentVariable("TMPDIR") ?? "/tmp",
-                "Serilog.Sinks.Seq.Tests",
-                Session.ToString("n"),
-                name ?? Guid.NewGuid().ToString("n"));
-
-            Directory.CreateDirectory(_tempFolder);
+            if (Directory.Exists(_tempFolder))
+                Directory.Delete(_tempFolder, true);
         }
-
-        public string Path => _tempFolder;
-
-        public void Dispose()
+        catch (Exception ex)
         {
-            try
-            {
-                if (Directory.Exists(_tempFolder))
-                    Directory.Delete(_tempFolder, true);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex);
-            }
+            Debug.WriteLine(ex);
         }
+    }
 
-        public string AllocateFilename(string? ext = null)
-        {
-            return System.IO.Path.Combine(Path, Guid.NewGuid().ToString("n") + "." + (ext ?? "tmp"));
-        }
+    public string AllocateFilename(string? ext = null)
+    {
+        return System.IO.Path.Combine(Path, Guid.NewGuid().ToString("n") + "." + (ext ?? "tmp"));
     }
 }


### PR DESCRIPTION
Updating to Serilog 3.1 and the matching _Serilog.Formatting.Compact_ ensures trace and span ids will reach Seq when available.

The PR is mostly housekeeping; dropping the .NET Core 1.x-era targets and supporting the later unsupported TFMs via the supported `netstandard2.0` one helps clean up the codebase and keep us in good stead to improve the sink in the future.

In the process - the durable log shipper's `PortableTimer` implementation could technically eat up thread pool threads in the case of there being very long batch flushing times. Not sure whether this would actually occur in normal use (the threads would be released each time the queue hit zero) but it's conceivable, so I've rolled in a tiny fix for this, too.

Finally, since there's really never any good time to make the change, I've included one final commit that updates the C# language version to 10 and switches to file-scoped namespaces; reviewers might need to check out this commit separately 😅 .

See also serilog/serilog#1923