### PR TITLE
Accept an `ITextFormatter` to customize payload formatting

### DIFF
--- a/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
@@ -1,4 +1,4 @@
-// Serilog.Sinks.Seq Copyright 2014-2019 Serilog Contributors
+// Serilog.Sinks.Seq Copyright © Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,14 +18,12 @@ using System.Text;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
-using Serilog.Formatting.Compact;
-using Serilog.Formatting.Json;
 using Serilog.Parsing;
 
 namespace Serilog.Sinks.Seq;
 
 /// <summary>
-/// Wraps a <see cref="CompactJsonFormatter" /> to suppress formatting errors and apply the event body size
+/// Wraps an <see cref="ITextFormatter" /> to suppress formatting errors and apply the event body size
 /// limit, if any. Placeholder events are logged when an event is unable to be written itself.
 /// </summary>
 sealed class ConstrainedBufferedFormatter : ITextFormatter
@@ -33,10 +31,11 @@ sealed class ConstrainedBufferedFormatter : ITextFormatter
     static readonly int NewLineByteCount = Encoding.UTF8.GetByteCount(Environment.NewLine);
         
     readonly long? _eventBodyLimitBytes;
-    readonly CompactJsonFormatter _jsonFormatter = new(new JsonValueFormatter("$type"));
+    readonly ITextFormatter _innerFormatter;
 
-    public ConstrainedBufferedFormatter(long? eventBodyLimitBytes)
+    public ConstrainedBufferedFormatter(long? eventBodyLimitBytes, ITextFormatter innerFormatter)
     {
+        _innerFormatter = innerFormatter;
         _eventBodyLimitBytes = eventBodyLimitBytes;
     }
 
@@ -51,7 +50,7 @@ sealed class ConstrainedBufferedFormatter : ITextFormatter
 
         try
         {
-            _jsonFormatter.Format(logEvent, buffer);
+            _innerFormatter.Format(logEvent, buffer);
         }
         catch (Exception ex) when (writePlaceholders)
         {

--- a/test/Serilog.Sinks.Seq.Tests/Audit/SeqAuditSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Audit/SeqAuditSinkTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Serilog.Debugging;
 using Serilog.Events;
+using Serilog.Formatting.Compact;
 using Serilog.Sinks.Seq.Audit;
 using Serilog.Sinks.Seq.Tests.Support;
 using Xunit;
@@ -39,7 +40,7 @@ public class SeqAuditSinkTests
     public void AuditSinkDisposesIngestionApi()
     {
         var api = new TestIngestionApi();
-        var sink = new SeqAuditSink(api);
+        var sink = new SeqAuditSink(api, new CompactJsonFormatter());
         Assert.False(api.IsDisposed);
             
         sink.Dispose();
@@ -53,7 +54,7 @@ public class SeqAuditSinkTests
         LogEvent evt1 = Some.InformationEvent("first"), evt2 = Some.InformationEvent("second");
             
         var api = new TestIngestionApi();
-        var sink = new SeqAuditSink(api);
+        var sink = new SeqAuditSink(api, new CompactJsonFormatter());
             
         sink.Emit(evt1);
         sink.Emit(evt2);
@@ -70,7 +71,7 @@ public class SeqAuditSinkTests
     {
         var expected = new Exception("Test");
         var api = new TestIngestionApi(_ => throw expected);
-        var sink = new SeqAuditSink(api);
+        var sink = new SeqAuditSink(api, new CompactJsonFormatter());
             
         var thrown = Assert.Throws<AggregateException>(() => sink.Emit(Some.InformationEvent()));
             

--- a/test/Serilog.Sinks.Seq.Tests/Batched/BatchedSeqSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Batched/BatchedSeqSinkTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Formatting.Compact;
 using Serilog.Sinks.Seq.Batched;
 using Serilog.Sinks.Seq.Http;
 using Serilog.Sinks.Seq.Tests.Support;
@@ -15,7 +16,7 @@ public class BatchedSeqSinkTests
     public void BatchedSinkDisposesIngestionApi()
     {
         var api = new TestIngestionApi();
-        var sink = new BatchedSeqSink(api, null, new ControlledLevelSwitch());
+        var sink = new BatchedSeqSink(api, new CompactJsonFormatter(), null, new ControlledLevelSwitch());
         Assert.False(api.IsDisposed);
             
         sink.Dispose();
@@ -27,7 +28,7 @@ public class BatchedSeqSinkTests
     public async Task EventsAreFormattedIntoPayloads()
     {
         var api = new TestIngestionApi();
-        var sink = new BatchedSeqSink(api, null, new ControlledLevelSwitch());
+        var sink = new BatchedSeqSink(api, new CompactJsonFormatter(), null, new ControlledLevelSwitch());
 
         await sink.EmitBatchAsync(new[]
         {
@@ -47,7 +48,7 @@ public class BatchedSeqSinkTests
         const LogEventLevel originalLevel = LogEventLevel.Debug, newLevel = LogEventLevel.Error;
         var levelSwitch = new LoggingLevelSwitch(originalLevel);
         var api = new TestIngestionApi(_ => Task.FromResult(new IngestionResult(true, HttpStatusCode.Accepted, newLevel)));
-        var sink = new BatchedSeqSink(api, null, new ControlledLevelSwitch(levelSwitch));
+        var sink = new BatchedSeqSink(api, new CompactJsonFormatter(), null, new ControlledLevelSwitch(levelSwitch));
 
         await sink.EmitBatchAsync(new[] { Some.InformationEvent() });
             

--- a/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Serilog.Formatting.Compact;
 using Serilog.Sinks.Seq.Tests.Support;
 using Xunit;
 
@@ -10,7 +11,7 @@ public class ConstrainedBufferedFormatterTests
     public void EventsAreFormattedIntoCompactJsonPayloads()
     {
         var evt = Some.LogEvent("Hello, {Name}!", "Alice");
-        var formatter = new ConstrainedBufferedFormatter(null);
+        var formatter = new ConstrainedBufferedFormatter(null, new CompactJsonFormatter());
         var json = new StringWriter();
         formatter.Format(evt, json);
         Assert.Contains("Name\":\"Alice", json.ToString());
@@ -20,7 +21,7 @@ public class ConstrainedBufferedFormatterTests
     public void PlaceholdersAreLoggedWhenCompactJsonRenderingFails()
     {
         var evt = Some.LogEvent(new NastyException(), "Hello, {Name}!", "Alice");
-        var formatter = new ConstrainedBufferedFormatter(null);
+        var formatter = new ConstrainedBufferedFormatter(null, new CompactJsonFormatter());
         var json = new StringWriter();
         formatter.Format(evt, json);
         var jsonString = json.ToString();
@@ -32,7 +33,7 @@ public class ConstrainedBufferedFormatterTests
     public void PlaceholdersAreLoggedWhenTheEventSizeLimitIsExceeded()
     {
         var evt = Some.LogEvent("Hello, {Name}!", new string('a', 10000));
-        var formatter = new ConstrainedBufferedFormatter(2000);
+        var formatter = new ConstrainedBufferedFormatter(2000, new CompactJsonFormatter());
         var json = new StringWriter();
         formatter.Format(evt, json);
         var jsonString = json.ToString();


### PR DESCRIPTION
Seq 2024.1 will support trace (span) ingestion, but Serilog doesn't have a built-in way to annotate `LogEvent`s with span start times or parent span ids.

This PR adds support for passing an `ITextFormatter` to the various `Seq()` sink configuration methods, and using that formatter to construct newline-delimited JSON payloads.

Hypothetically, if an enricher provides span starts in `SpanStart` and parent span ids in `ParentSpanId`, these could be sent to Seq in the `@st` and `@ps` payload properties using:

```csharp

Log.Logger = new LoggerConfiguration()
    .WriteTo.Seq(
        "https://seq.example.com",
        payloadFormatter: new ExpressionTemplate(
            "{ {@t, @mt, @l: if @l = 'Information' then undefined() else @l, @x, @sp, @tr, @ps: ParentSpanId, @st: SpanStart, @ra: {service: {name: 'Example'}}, ..rest()} }\n"))
    .CreateLogger();
```

