### PR TITLE
Automatically recognize `SpanStartTimestamp`, `ParentSpanId`, and `SpanKind` from SerilogTracing

### DIFF
--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -19,7 +19,6 @@ using Serilog.Events;
 using Serilog.Sinks.Seq;
 using System.Net.Http;
 using Serilog.Formatting;
-using Serilog.Formatting.Compact;
 using Serilog.Sinks.PeriodicBatching;
 using Serilog.Sinks.Seq.Batched;
 using Serilog.Sinks.Seq.Audit;
@@ -36,7 +35,7 @@ public static class SeqLoggerConfigurationExtensions
     const int DefaultBatchPostingLimit = 1000;
     static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
     const int DefaultQueueSizeLimit = 100000;
-    static ITextFormatter CreateDefaultFormatter() => new CompactJsonFormatter(new("$type"));
+    static ITextFormatter CreateDefaultFormatter() => new SeqCompactJsonFormatter();
 
     /// <summary>
     /// Write log events to a <a href="https://datalust.co/seq">Seq</a> server.

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -31,7 +31,6 @@
   <ItemGroup>
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0-dev-*" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/SeqCompactJsonFormatter.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/SeqCompactJsonFormatter.cs
@@ -1,0 +1,164 @@
+// Copyright 2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using Serilog.Parsing;
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace Serilog.Sinks.Seq;
+
+/// <summary>
+/// An <see cref="ITextFormatter"/> that writes events in a compact JSON format.
+/// </summary>
+/// <remarks>Modified from <c>Serilog.Formatting.Compact.CompactJsonFormatter</c> to add
+/// implicit SerilogTracing span support.</remarks>
+public class SeqCompactJsonFormatter: ITextFormatter
+{
+    readonly JsonValueFormatter _valueFormatter = new("$type");
+
+    /// <summary>
+    /// Format the log event into the output. Subsequent events will be newline-delimited.
+    /// </summary>
+    /// <param name="logEvent">The event to format.</param>
+    /// <param name="output">The output.</param>
+    public void Format(LogEvent logEvent, TextWriter output)
+    {
+        FormatEvent(logEvent, output, _valueFormatter);
+        output.WriteLine();
+    }
+
+    /// <summary>
+    /// Format the log event into the output.
+    /// </summary>
+    /// <param name="logEvent">The event to format.</param>
+    /// <param name="output">The output.</param>
+    /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
+    public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter)
+    {
+        if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+        if (output == null) throw new ArgumentNullException(nameof(output));
+        if (valueFormatter == null) throw new ArgumentNullException(nameof(valueFormatter));
+
+        output.Write("{\"@t\":\"");
+        output.Write(logEvent.Timestamp.UtcDateTime.ToString("O"));
+        output.Write("\",\"@mt\":");
+        JsonValueFormatter.WriteQuotedJsonString(logEvent.MessageTemplate.Text, output);
+
+        var tokensWithFormat = logEvent.MessageTemplate.Tokens
+            .OfType<PropertyToken>()
+            .Where(pt => pt.Format != null);
+
+        // Better not to allocate an array in the 99.9% of cases where this is false
+        // ReSharper disable once PossibleMultipleEnumeration
+        if (tokensWithFormat.Any())
+        {
+            output.Write(",\"@r\":[");
+            var delim = "";
+            foreach (var r in tokensWithFormat)
+            {
+                output.Write(delim);
+                delim = ",";
+                var space = new StringWriter();
+                r.Render(logEvent.Properties, space, CultureInfo.InvariantCulture);
+                JsonValueFormatter.WriteQuotedJsonString(space.ToString(), output);
+            }
+            output.Write(']');
+        }
+
+        if (logEvent.Level != LogEventLevel.Information)
+        {
+            output.Write(",\"@l\":\"");
+            output.Write(logEvent.Level);
+            output.Write('\"');
+        }
+
+        if (logEvent.Exception != null)
+        {
+            output.Write(",\"@x\":");
+            JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
+        }
+
+        if (logEvent.TraceId != null)
+        {
+            output.Write(",\"@tr\":\"");
+            output.Write(logEvent.TraceId.Value.ToHexString());
+            output.Write('\"');
+        }
+
+        if (logEvent.SpanId != null)
+        {
+            output.Write(",\"@sp\":\"");
+            output.Write(logEvent.SpanId.Value.ToHexString());
+            output.Write('\"');
+        }
+
+        var skipSpanProperties = false;
+        if (logEvent is {TraceId: not null, SpanId: not null} &&
+            logEvent.Properties.TryGetValue("SpanStartTimestamp", out var st) &&
+            st is ScalarValue { Value: DateTime spanStartTimestamp })
+        {
+            skipSpanProperties = true;
+                
+            output.Write(",\"@st\":\"");
+            output.Write(spanStartTimestamp.ToString("o"));
+            output.Write('\"');
+
+            if (logEvent.Properties.TryGetValue("ParentSpanId", out var ps) &&
+                ps is ScalarValue { Value: ActivitySpanId parentSpanId })
+            {
+                output.Write(",\"@ps\":\"");
+                output.Write(parentSpanId.ToHexString());
+                output.Write('\"');
+            }
+
+            if (logEvent.Properties.TryGetValue("SpanKind", out var sk) &&
+                sk is ScalarValue { Value: ActivityKind spanKind } &&
+                spanKind != ActivityKind.Internal)
+            {
+                output.Write(",\"@sk\":\"");
+                output.Write(spanKind);
+                output.Write('\"');
+            }
+        }
+            
+        foreach (var property in logEvent.Properties)
+        {
+            var name = property.Key;
+                
+            if (skipSpanProperties && name is "SpanStartTimestamp" or "ParentSpanId" or "SpanKind")
+                continue;
+                
+            if (name.Length > 0 && name[0] == '@')
+            {
+                // Escape first '@' by doubling
+                name = '@' + name;
+            }
+
+            output.Write(',');
+            JsonValueFormatter.WriteQuotedJsonString(name, output);
+            output.Write(':');
+            valueFormatter.Format(property.Value, output);
+        }
+
+        output.Write('}');
+    }
+}

--- a/test/Serilog.Sinks.Seq.Tests/Audit/SeqAuditSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Audit/SeqAuditSinkTests.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Serilog.Debugging;
 using Serilog.Events;
-using Serilog.Formatting.Compact;
 using Serilog.Sinks.Seq.Audit;
 using Serilog.Sinks.Seq.Tests.Support;
 using Xunit;
@@ -40,7 +39,7 @@ public class SeqAuditSinkTests
     public void AuditSinkDisposesIngestionApi()
     {
         var api = new TestIngestionApi();
-        var sink = new SeqAuditSink(api, new CompactJsonFormatter());
+        var sink = new SeqAuditSink(api, new SeqCompactJsonFormatter());
         Assert.False(api.IsDisposed);
             
         sink.Dispose();
@@ -54,7 +53,7 @@ public class SeqAuditSinkTests
         LogEvent evt1 = Some.InformationEvent("first"), evt2 = Some.InformationEvent("second");
             
         var api = new TestIngestionApi();
-        var sink = new SeqAuditSink(api, new CompactJsonFormatter());
+        var sink = new SeqAuditSink(api, new SeqCompactJsonFormatter());
             
         sink.Emit(evt1);
         sink.Emit(evt2);
@@ -71,7 +70,7 @@ public class SeqAuditSinkTests
     {
         var expected = new Exception("Test");
         var api = new TestIngestionApi(_ => throw expected);
-        var sink = new SeqAuditSink(api, new CompactJsonFormatter());
+        var sink = new SeqAuditSink(api, new SeqCompactJsonFormatter());
             
         var thrown = Assert.Throws<AggregateException>(() => sink.Emit(Some.InformationEvent()));
             

--- a/test/Serilog.Sinks.Seq.Tests/Batched/BatchedSeqSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Batched/BatchedSeqSinkTests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Serilog.Core;
 using Serilog.Events;
-using Serilog.Formatting.Compact;
 using Serilog.Sinks.Seq.Batched;
 using Serilog.Sinks.Seq.Http;
 using Serilog.Sinks.Seq.Tests.Support;
@@ -16,7 +15,7 @@ public class BatchedSeqSinkTests
     public void BatchedSinkDisposesIngestionApi()
     {
         var api = new TestIngestionApi();
-        var sink = new BatchedSeqSink(api, new CompactJsonFormatter(), null, new ControlledLevelSwitch());
+        var sink = new BatchedSeqSink(api, new SeqCompactJsonFormatter(), null, new ControlledLevelSwitch());
         Assert.False(api.IsDisposed);
             
         sink.Dispose();
@@ -28,7 +27,7 @@ public class BatchedSeqSinkTests
     public async Task EventsAreFormattedIntoPayloads()
     {
         var api = new TestIngestionApi();
-        var sink = new BatchedSeqSink(api, new CompactJsonFormatter(), null, new ControlledLevelSwitch());
+        var sink = new BatchedSeqSink(api, new SeqCompactJsonFormatter(), null, new ControlledLevelSwitch());
 
         await sink.EmitBatchAsync(new[]
         {
@@ -48,7 +47,7 @@ public class BatchedSeqSinkTests
         const LogEventLevel originalLevel = LogEventLevel.Debug, newLevel = LogEventLevel.Error;
         var levelSwitch = new LoggingLevelSwitch(originalLevel);
         var api = new TestIngestionApi(_ => Task.FromResult(new IngestionResult(true, HttpStatusCode.Accepted, newLevel)));
-        var sink = new BatchedSeqSink(api, new CompactJsonFormatter(), null, new ControlledLevelSwitch(levelSwitch));
+        var sink = new BatchedSeqSink(api, new SeqCompactJsonFormatter(), null, new ControlledLevelSwitch(levelSwitch));
 
         await sink.EmitBatchAsync(new[] { Some.InformationEvent() });
             

--- a/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/ConstrainedBufferedFormatterTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using Serilog.Formatting.Compact;
 using Serilog.Sinks.Seq.Tests.Support;
 using Xunit;
 
@@ -11,7 +10,7 @@ public class ConstrainedBufferedFormatterTests
     public void EventsAreFormattedIntoCompactJsonPayloads()
     {
         var evt = Some.LogEvent("Hello, {Name}!", "Alice");
-        var formatter = new ConstrainedBufferedFormatter(null, new CompactJsonFormatter());
+        var formatter = new ConstrainedBufferedFormatter(null, new SeqCompactJsonFormatter());
         var json = new StringWriter();
         formatter.Format(evt, json);
         Assert.Contains("Name\":\"Alice", json.ToString());
@@ -21,7 +20,7 @@ public class ConstrainedBufferedFormatterTests
     public void PlaceholdersAreLoggedWhenCompactJsonRenderingFails()
     {
         var evt = Some.LogEvent(new NastyException(), "Hello, {Name}!", "Alice");
-        var formatter = new ConstrainedBufferedFormatter(null, new CompactJsonFormatter());
+        var formatter = new ConstrainedBufferedFormatter(null, new SeqCompactJsonFormatter());
         var json = new StringWriter();
         formatter.Format(evt, json);
         var jsonString = json.ToString();
@@ -33,7 +32,7 @@ public class ConstrainedBufferedFormatterTests
     public void PlaceholdersAreLoggedWhenTheEventSizeLimitIsExceeded()
     {
         var evt = Some.LogEvent("Hello, {Name}!", new string('a', 10000));
-        var formatter = new ConstrainedBufferedFormatter(2000, new CompactJsonFormatter());
+        var formatter = new ConstrainedBufferedFormatter(2000, new SeqCompactJsonFormatter());
         var json = new StringWriter();
         formatter.Format(evt, json);
         var jsonString = json.ToString();

--- a/test/Serilog.Sinks.Seq.Tests/SeqCompactJsonFormatterTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/SeqCompactJsonFormatterTests.cs
@@ -1,0 +1,170 @@
+// This file originally CompactJsonFormatterTests from https://github.com/serilog/serilog-formatting-compact,
+// Copyright Serilog Contributors and distributed under the Apache 2.0 license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+// ReSharper disable AccessToDisposedClosure
+
+namespace Serilog.Sinks.Seq.Tests;
+
+public class SeqCompactJsonFormatterTests
+{
+    JObject AssertValidJson(Action<ILogger> act)
+    {
+        var sw = new StringWriter();
+        var logger = new LoggerConfiguration()
+            .Destructure.AsScalar<ActivityTraceId>()
+            .Destructure.AsScalar<ActivitySpanId>()
+            .WriteTo.TextWriter(new SeqCompactJsonFormatter(), sw)
+            .CreateLogger();
+        act(logger);
+        logger.Dispose();
+        var json = sw.ToString();
+
+        var settings = new JsonSerializerSettings
+        {
+            DateParseHandling = DateParseHandling.None,
+            CheckAdditionalContent = true,
+        };
+        
+        return JsonConvert.DeserializeObject<JObject>(json, settings)!;
+    }
+
+    [Fact]
+    public void AnEmptyEventIsValidJson()
+    {
+        AssertValidJson(log => log.Information("No properties"));
+    }
+
+    [Fact]
+    public void AMinimalEventIsValidJson()
+    {
+        AssertValidJson(log => log.Information("One {Property}", 42));
+    }
+
+    [Fact]
+    public void MultiplePropertiesAreDelimited()
+    {
+        AssertValidJson(log => log.Information("Property {First} and {Second}", "One", "Two"));
+    }
+
+    [Fact]
+    public void ExceptionsAreFormattedToValidJson()
+    {
+        AssertValidJson(log => log.Information(new DivideByZeroException(), "With exception"));
+    }
+
+    [Fact]
+    public void ExceptionAndPropertiesAreValidJson()
+    {
+        AssertValidJson(log => log.Information(new DivideByZeroException(), "With exception and {Property}", 42));
+    }
+
+    [Fact]
+    public void RenderingsAreValidJson()
+    {
+        AssertValidJson(log => log.Information("One {Rendering:x8}", 42));
+    }
+
+    [Fact]
+    public void MultipleRenderingsAreDelimited()
+    {
+        AssertValidJson(log => log.Information("Rendering {First:x8} and {Second:x8}", 1, 2));
+    }
+
+    [Fact]
+    public void AtPrefixedPropertyNamesAreEscaped()
+    {
+        // Not possible in message templates, but accepted this way
+        var jObject = AssertValidJson(log => log.ForContext("@Mistake", 42)
+                                                .Information("Hello"));
+
+        Assert.True(jObject.TryGetValue("@@Mistake", out var val));
+        Assert.Equal(42, val.ToObject<int>());
+    }
+
+    [Fact]
+    public void TimestampIsUtc()
+    {
+        // Not possible in message templates, but accepted this way
+        var jObject = AssertValidJson(log => log.Information("Hello"));
+
+        Assert.True(jObject.TryGetValue("@t", out var val));
+        Assert.EndsWith("Z", val.ToObject<string>());
+    }
+
+    [Fact]
+    public void TraceAndSpanIdsGenerateValidJson()
+    {
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var evt = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
+            new MessageTemplate(Enumerable.Empty<MessageTemplateToken>()), Enumerable.Empty<LogEventProperty>(),
+            traceId, spanId);
+        var json = AssertValidJson(log => log.Write(evt));
+        Assert.Equal(traceId.ToHexString(), json["@tr"]);
+        Assert.Equal(spanId.ToHexString(), json["@sp"]);
+    }
+    
+    [Fact]
+    public void RecognizesSerilogTracingProperties()
+    {
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        
+        using var source = new ActivitySource(nameof(SeqCompactJsonFormatterTests));
+        
+        using var listener = new ActivityListener();
+        listener.ShouldListenTo = s => s.Name == source.Name;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
+        ActivitySource.AddActivityListener(listener);
+
+        using var parent = source.StartActivity();
+        Assert.NotNull(parent);
+
+        using var child = source.StartActivity();
+        Assert.NotNull(child);
+        
+        var st = DateTime.UtcNow;
+        var tr = child.TraceId;
+        var sp = child.SpanId;
+        var ps = parent.SpanId;
+        const ActivityKind sk = ActivityKind.Server;
+        
+        var jObject = AssertValidJson(log => log.Information("{SpanStartTimestamp} {ParentSpanId} {SpanKind}", st, ps, sk));
+
+        Assert.False(jObject.ContainsKey("SpanStartTimestamp"));
+
+        Assert.True(jObject.TryGetValue("@st", out var stValue));
+        Assert.Equal(st.ToString("o"), stValue.ToObject<string>());
+
+        Assert.True(jObject.TryGetValue("@tr", out var trValue));
+        Assert.Equal(tr.ToHexString(), trValue.ToObject<string>());
+
+        Assert.True(jObject.TryGetValue("@sp", out var spValue));
+        Assert.Equal(sp.ToHexString(), spValue.ToObject<string>());
+
+        Assert.True(jObject.TryGetValue("@ps", out var psValue));
+        Assert.Equal(ps.ToHexString(), psValue.ToObject<string>());
+
+        Assert.True(jObject.TryGetValue("@sk", out var skValue));
+        Assert.Equal("Server", skValue.ToObject<string>());
+    }
+    
+    [Fact]
+    public void IgnoresSerilogTracingPropertiesWhenNotTracing()
+    {
+        var st = DateTime.UtcNow;
+        var jObject = AssertValidJson(log => log.Information("{SpanStartTimestamp}", st));
+
+        Assert.True(jObject.ContainsKey("SpanStartTimestamp"));
+        
+        Assert.False(jObject.ContainsKey("@st"));
+    }
+}

--- a/test/Serilog.Sinks.Seq.Tests/Serilog.Sinks.Seq.Tests.csproj
+++ b/test/Serilog.Sinks.Seq.Tests/Serilog.Sinks.Seq.Tests.csproj
@@ -35,6 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net4.8' ">


### PR DESCRIPTION
SerilogTracing is a nice low-dependency way to light up Serilog output with timed/hierarchical traces. Its tracing output boils down to three properties, listed in the title.

There's currently a `SerilogTracing.Sinks.Seq` package that maps these three properties into underlying top-level compact JSON fields to send to Seq.

Since the whole thing is gated on the existence of `SpanStartTimestamp`, on a log event that is already marked with a trace and span id, adding support directly here seems reasonable: it's unlikely this will break any existing usage, and we'll avoid having to support yet another same-but-not-quite client library for people who want to use Serilog with tracing.

`SpanStartTimestamp` maps to `@st`, which Seq already recognizes, and this is the case for `ParentSpanId` mapping to `@ps`, also.

The `@sk` property name is not currently recognized by Seq and will be recorded verbatim; I'm expecting we'll either ignore or ingest this in 2024.2, and we'll have time to validate that decision before this sink reaches 7.0.0.