### PR TITLE
Default the sink to not tracing its own outbound requests, when possible

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.201",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -36,7 +36,7 @@ public static class SeqLoggerConfigurationExtensions
     static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
     const int DefaultQueueSizeLimit = 100000;
     static ITextFormatter CreateDefaultFormatter() => new SeqCompactJsonFormatter();
-
+    
     /// <summary>
     /// Write log events to a <a href="https://datalust.co/seq">Seq</a> server.
     /// </summary>


### PR DESCRIPTION
In apps that use tracing (any `ActivityListener`-based implementation), `HttpClient` can generate spans for outbound HTTP requests by default. The periodic requests from this sink end up creating noisy, unhelpful spans.

This PR switches that behavior off by default, on .NET 6 and later.