### PR TITLE
Fix SeqIngestionApi not calling TryIngestAsync with ConfigureAwait(false)

### DIFF
--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Http/SeqIngestionApi.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Http/SeqIngestionApi.cs
@@ -51,7 +51,7 @@ abstract class SeqIngestionApi : IDisposable
     /// <exception cref="HttpRequestException">The ingestion request could not be sent.</exception>
     public async Task<LogEventLevel?> IngestAsync(string clefPayload)
     {
-        var result = await TryIngestAsync(clefPayload, CompactLogEventFormatMediaType);
+        var result = await TryIngestAsync(clefPayload, CompactLogEventFormatMediaType).ConfigureAwait(false);
 
         if (!result.Succeeded)
             throw new LoggingFailedException($"Received failed result {result.StatusCode} when posting events to Seq.");


### PR DESCRIPTION
`SeqIngestionApi` is missing a call to `ConfigureAwait(false)`. When writing events to a `SeqAuditSink` from a thread that has a synchronization context, `SeqAuditSink.Emit` will block the thread waiting for the `HttpClient` request to complete, causing a deadlock when the synchronization context tries to resume on the thread that `SeqAuditSink.Emit` is blocking