### PR TITLE
Update to Serilog 4 (prerelease)

### DIFF
--- a/sample/BlazorWasm/BlazorWasm.csproj
+++ b/sample/BlazorWasm/BlazorWasm.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.4" PrivateAssets="all" />
     <PackageReference Include="serilog.extensions.logging" Version="8.0.0" />
     <PackageReference Include="serilog.sinks.browserconsole" Version="2.0.0" />
   </ItemGroup>

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -19,7 +19,7 @@
     <RepositoryUrl>https://github.com/datalust/serilog-sinks-seq</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
+++ b/src/Serilog.Sinks.Seq/Serilog.Sinks.Seq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Serilog sink that writes events to Seq using newline-delimited JSON and HTTP/HTTPS.</Description>
-    <VersionPrefix>7.0.2</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Serilog Contributors;Serilog.Sinks.Seq Contributors;Datalust Pty Ltd</Authors>
     <Copyright>Copyright © Serilog Contributors, Serilog.Sinks.Seq Contributors, Datalust Pty Ltd.</Copyright>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
@@ -29,8 +29,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="4.0.0-*" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Batched/BatchedSeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Batched/BatchedSeqSink.cs
@@ -59,7 +59,7 @@ sealed class BatchedSeqSink : IBatchedLogEventSink, IDisposable
         if (_controlledSwitch.IsActive &&
             _nextRequiredLevelCheckUtc < DateTime.UtcNow)
         {
-            await EmitBatchAsync(Array.Empty<LogEvent>());
+            await EmitBatchAsync([]);
         }
     }
 

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Batched/BatchedSeqSink.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Batched/BatchedSeqSink.cs
@@ -15,17 +15,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
+using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
-using Serilog.Sinks.PeriodicBatching;
 using Serilog.Sinks.Seq.Http;
 
 namespace Serilog.Sinks.Seq.Batched;
 
 /// <summary>
-/// The default Seq sink, for use in combination with <see cref="PeriodicBatchingSink"/>.
+/// The default Seq sink.
 /// </summary>
 sealed class BatchedSeqSink : IBatchedLogEventSink, IDisposable
 {
@@ -60,11 +59,11 @@ sealed class BatchedSeqSink : IBatchedLogEventSink, IDisposable
         if (_controlledSwitch.IsActive &&
             _nextRequiredLevelCheckUtc < DateTime.UtcNow)
         {
-            await EmitBatchAsync(Enumerable.Empty<LogEvent>());
+            await EmitBatchAsync(Array.Empty<LogEvent>());
         }
     }
 
-    public async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+    public async Task EmitBatchAsync(IReadOnlyCollection<LogEvent> events)
     {
         _nextRequiredLevelCheckUtc = DateTime.UtcNow.Add(RequiredLevelCheckInterval);
 

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/BookmarkFile.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/BookmarkFile.cs
@@ -39,7 +39,7 @@ sealed class BookmarkFile : IDisposable
 
             if (current != null)
             {
-                var parts = current.Split(new[] { ":::" }, StringSplitOptions.RemoveEmptyEntries);
+                var parts = current.Split([":::"], StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Length == 2)
                 {
                     return new FileSetPosition(long.Parse(parts[0]), parts[1]);

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/ExponentialBackoffConnectionSchedule.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/ExponentialBackoffConnectionSchedule.cs
@@ -17,7 +17,7 @@ using System;
 namespace Serilog.Sinks.Seq.Durable;
 
 /// <summary>
-/// Based on the BatchedConnectionStatus class from <see cref="Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink"/>.
+/// Based on the <c>BatchedConnectionStatus</c> class from <c>Serilog.Sinks.PeriodicBatching</c>.
 /// </summary>
 sealed class ExponentialBackoffConnectionSchedule
 {
@@ -30,7 +30,7 @@ sealed class ExponentialBackoffConnectionSchedule
 
     public ExponentialBackoffConnectionSchedule(TimeSpan period)
     {
-        if (period < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), "The connection retry period must be a positive timespan");
+        if (period < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), "The connection retry period must be a positive timespan.");
        
         _period = period;
     }
@@ -55,7 +55,7 @@ sealed class ExponentialBackoffConnectionSchedule
             // Second failure, start ramping up the interval - first 2x, then 4x, ...
             var backoffFactor = Math.Pow(2, (_failuresSinceSuccessfulConnection - 1));
 
-            // If the period is ridiculously short, give it a boost so we get some
+            // If the period is ridiculously short, give it a boost so that we get some
             // visible backoff.
             var backoffPeriod = Math.Max(_period.Ticks, MinimumBackoffPeriod.Ticks);
 

--- a/test/Serilog.Sinks.Seq.Tests/Durable/PayloadReaderTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Durable/PayloadReaderTests.cs
@@ -17,7 +17,9 @@ public class PayloadReaderTests
     {
         using var tmp = new TempFolder();
         var fn = tmp.AllocateFilename("clef");
-        var lines = IOFile.ReadAllText(Path.Combine("Resources", "ThreeBufferedEvents.clef.txt"), Encoding.UTF8).Split(new [] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
+        var lines = IOFile.ReadAllText(Path.Combine("Resources", "ThreeBufferedEvents.clef.txt"), Encoding.UTF8)
+            // ReSharper disable once RedundantCast
+            .Split((char[])['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
         using (var f = IOFile.Create(fn))
         using (var fw = new StreamWriter(f, Encoding.UTF8))
         {
@@ -42,7 +44,9 @@ public class PayloadReaderTests
     {
         using var tmp = new TempFolder();
         var fn = tmp.AllocateFilename("json");
-        var lines = IOFile.ReadAllText(Path.Combine("Resources", "ThreeBufferedEvents.json.txt"), Encoding.UTF8).Split(new [] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
+        var lines = IOFile.ReadAllText(Path.Combine("Resources", "ThreeBufferedEvents.json.txt"), Encoding.UTF8)
+            // ReSharper disable once RedundantCast
+            .Split((char[])['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
         using (var f = IOFile.Create(fn))
         using (var fw = new StreamWriter(f, Encoding.UTF8))
         {

--- a/test/Serilog.Sinks.Seq.Tests/Serilog.Sinks.Seq.Tests.csproj
+++ b/test/Serilog.Sinks.Seq.Tests/Serilog.Sinks.Seq.Tests.csproj
@@ -28,13 +28,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.4" />
+    <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Drops the _Serilog.Sinks.PeriodicBatching_ dependency. There isn't any breaking or visible surface area change, but pulling Serilog up a major version, and no longer pulling in the latest _s.s.PeriodicBatching_ will have enough impact on consumers to warrant a major version bump.