### PR TITLE
Update to match fixed namespace for `BatchingOptions`

### DIFF
--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -18,7 +18,6 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.Seq;
 using System.Net.Http;
-using Serilog.Core.Sinks.Batching;
 using Serilog.Formatting;
 using Serilog.Sinks.Seq.Batched;
 using Serilog.Sinks.Seq.Audit;


### PR DESCRIPTION
The first Serilog version to include this put it in the wrong namespace.