### PR TITLE
Custom format provider

### DIFF
--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -68,7 +68,8 @@ public static class SeqLoggerConfigurationExtensions
     /// durable log shipping.</param>
     /// <param name="payloadFormatter">An <see cref="ITextFormatter"/> that will be used to format (newline-delimited CLEF/JSON)
     /// payloads. Experimental.</param>
-    /// <param name="formatProvider">An <see cref="IFormatProvider"/> that will be used to render log event tokens. Does not apply if `payloadFormatter` is provided.</param>
+    /// <param name="formatProvider">An <see cref="IFormatProvider"/> that will be used to render log event tokens. Does not apply if `payloadFormatter` is provided.
+    /// If `formatProvider` is provided then event messages will be rendered and included in the payload.</param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
     public static LoggerConfiguration Seq(

--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -68,8 +68,8 @@ public static class SeqLoggerConfigurationExtensions
     /// durable log shipping.</param>
     /// <param name="payloadFormatter">An <see cref="ITextFormatter"/> that will be used to format (newline-delimited CLEF/JSON)
     /// payloads. Experimental.</param>
-    /// <param name="formatProvider">An <see cref="IFormatProvider"/> that will be used to render log event tokens. Does not apply if `payloadFormatter` is provided.
-    /// If `formatProvider` is provided then event messages will be rendered and included in the payload.</param>
+    /// <param name="formatProvider">An <see cref="IFormatProvider"/> that will be used to render log event tokens. Does not apply if <paramref name="payloadFormatter"/> is provided.
+    /// If <paramref name="formatProvider"/> is provided then event messages will be rendered and included in the payload.</param>
     /// <returns>Logger configuration, allowing configuration to continue.</returns>
     /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
     public static LoggerConfiguration Seq(

--- a/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Seq/SeqLoggerConfigurationExtensions.cs
@@ -165,7 +165,7 @@ public static class SeqLoggerConfigurationExtensions
         if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
 
         var ingestionApi = new SeqIngestionApiClient(serverUrl, apiKey, messageHandler);
-        var sink = new SeqAuditSink(ingestionApi, payloadFormatter ?? CreateDefaultFormatter(formatProvider ?? CultureInfo.InvariantCulture));
+        var sink = new SeqAuditSink(ingestionApi, payloadFormatter ?? CreateDefaultFormatter(formatProvider));
         return loggerAuditSinkConfiguration.Sink(sink, restrictedToMinimumLevel);
     }
 }

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using Serilog.Debugging;

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/ConstrainedBufferedFormatter.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Globalization;
 using System.IO;
 using System.Text;
 using Serilog.Debugging;

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Formatting/CleanMessageTemplateFormatter.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Formatting/CleanMessageTemplateFormatter.cs
@@ -1,0 +1,146 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Serilog.Events;
+using Serilog.Formatting.Json;
+using Serilog.Parsing;
+
+namespace Serilog.Sinks.Seq.Formatting;
+
+/// <summary>
+/// Matches the `:lj` clean formatting style now employed by Serilog.Expressions, Serilog.Sinks.Console, and elsewhere.
+/// In this mode, strings embedded in message templates are unquoted, and structured data is rendered as JSON.
+/// </summary>
+/// <remarks>This implementation is derived from the Serilog.Expressions one, sans theming support, and avoiding the
+/// extra dependency. In time there should be core Serilog support for this.</remarks>
+static class CleanMessageTemplateFormatter
+{
+    static readonly JsonValueFormatter SharedJsonValueFormatter = new("$type");
+    
+    public static string Format(MessageTemplate messageTemplate, IReadOnlyDictionary<string, LogEventPropertyValue> properties, IFormatProvider? formatProvider)
+    {
+        var output = new StringWriter();
+
+        foreach (var token in messageTemplate.Tokens)
+        {
+            switch (token)
+            {
+                case TextToken tt:
+                {
+                    output.Write(tt.Text);
+                    break;
+                }
+                case PropertyToken pt:
+                {
+                    RenderPropertyToken(properties, pt, output, formatProvider);
+                    break;
+                }
+                default:
+                {
+                    output.Write(token);
+                    break;
+                }
+            }
+        }
+
+        return output.ToString();
+    }
+
+    static void RenderPropertyToken(IReadOnlyDictionary<string, LogEventPropertyValue> properties, PropertyToken pt, TextWriter output, IFormatProvider? formatProvider)
+    {
+        if (!properties.TryGetValue(pt.PropertyName, out var value))
+        {
+            output.Write(pt.ToString());
+            return;
+        }
+
+        if (pt.Alignment is null)
+        {
+            RenderPropertyValueUnaligned(value, output, pt.Format, formatProvider);
+            return;
+        }
+
+        var buffer = new StringWriter();
+
+        RenderPropertyValueUnaligned(value, buffer, pt.Format, formatProvider);
+
+        var result = buffer.ToString();
+
+        if (result.Length >= pt.Alignment.Value.Width)
+            output.Write(result);
+        else
+            Padding.Apply(output, result, pt.Alignment.Value);
+    }
+
+    static void RenderPropertyValueUnaligned(LogEventPropertyValue propertyValue, TextWriter output, string? format, IFormatProvider? formatProvider)
+    {
+        if (propertyValue is not ScalarValue scalar)
+        {
+            SharedJsonValueFormatter.Format(propertyValue, output);
+            return;
+        }
+
+        var value = scalar.Value;
+
+        if (value == null)
+        {
+            output.Write("null");
+            return;
+        }
+
+        if (value is string str)
+        {
+            output.Write(str);
+            return;
+        }
+
+        if (value is ValueType)
+        {
+            if (value is int or uint or long or ulong or decimal or byte or sbyte or short or ushort)
+            {
+                output.Write(((IFormattable)value).ToString(format, formatProvider));
+                return;
+            }
+
+            if (value is double d)
+            {
+                output.Write(d.ToString(format, formatProvider));
+                return;
+            }
+
+            if (value is float f)
+            {
+                output.Write(f.ToString(format, formatProvider));
+                return;
+            }
+
+            if (value is bool b)
+            {
+                output.Write(b);
+                return;
+            }
+        }
+
+        if (value is IFormattable formattable)
+        {
+            output.Write(formattable.ToString(format, formatProvider));
+            return;
+        }
+
+        output.Write(value);
+    }
+}

--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Formatting/Padding.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Formatting/Padding.cs
@@ -1,0 +1,54 @@
+// Copyright © Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using System.Linq;
+using Serilog.Parsing;
+
+namespace Serilog.Sinks.Seq.Formatting
+{
+    static class Padding
+    {
+        static readonly char[] PaddingChars = Enumerable.Repeat(' ', 80).ToArray();
+
+        /// <summary>
+        /// Writes the provided value to the output, applying direction-based padding when <paramref name="alignment"/> is provided.
+        /// </summary>
+        public static void Apply(TextWriter output, string value, Alignment alignment)
+        {
+            if (value.Length >= alignment.Width)
+            {
+                output.Write(value);
+                return;
+            }
+
+            var pad = alignment.Width - value.Length;
+
+            if (alignment.Direction == AlignmentDirection.Left)
+                output.Write(value);
+
+            if (pad <= PaddingChars.Length)
+            {
+                output.Write(PaddingChars, 0, pad);
+            }
+            else
+            {
+                output.Write(new string(' ', pad));
+            }
+
+            if (alignment.Direction == AlignmentDirection.Right)
+                output.Write(value);
+        }
+    }
+}


### PR DESCRIPTION
See https://github.com/datalust/serilog-sinks-seq/issues/150

This PR allows an `IFormatProvider` to be supplied during the sinks configuration. If supplied the format provider is used to format message tokens. 

The `PropertiesFormatCorrectlyForTheFormatProvider` test is a reasonable summary of the behavior change. 

Note that if an `IFormatProvider` is specified then the message will be rendered and sent in the payload.