### PR TITLE
Don't write a spurious `SelfLog` event when disposing an unused sink in durable mode

### DIFF
--- a/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/BookmarkFile.cs
+++ b/src/Serilog.Sinks.Seq/Sinks/Seq/Durable/BookmarkFile.cs
@@ -24,6 +24,12 @@ sealed class BookmarkFile : IDisposable
 
     public BookmarkFile(string bookmarkFilename)
     {
+        var directory = Path.GetDirectoryName(bookmarkFilename);
+        if (!string.IsNullOrWhiteSpace(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        
         _bookmark = System.IO.File.Open(bookmarkFilename, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
     }
 

--- a/test/Serilog.Sinks.Seq.Tests/Durable/DurableSeqSinkTests.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Durable/DurableSeqSinkTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog.Sinks.Seq.Durable;
+using Serilog.Sinks.Seq.Http;
+using Serilog.Sinks.Seq.Tests.Support;
+using Xunit;
+
+namespace Serilog.Sinks.Seq.Tests.Durable;
+
+public class DurableSeqSinkTests
+{
+    [Fact]
+    public void SinkCanBeDisposedCleanlyWhenUnused()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("n"), "buffer");
+        var sink = new DurableSeqSink(
+            new TestIngestionApi(_ => Task.FromResult(new IngestionResult(true, HttpStatusCode.Accepted, null))),
+            new SeqCompactJsonFormatter(),
+            path,
+            100,
+            TimeSpan.FromSeconds(1),
+            null,
+            null,
+            new ControlledLevelSwitch(),
+            null);
+        
+        // No events written, so files/paths should not exist;
+        Assert.False(Directory.Exists(path));
+
+        using var collector = new SelfLogCollector();
+        sink.Dispose();
+        Assert.Empty(collector.Messages);
+    }
+}

--- a/test/Serilog.Sinks.Seq.Tests/Support/SelfLogCollector.cs
+++ b/test/Serilog.Sinks.Seq.Tests/Support/SelfLogCollector.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Serilog.Debugging;
+
+namespace Serilog.Sinks.Seq.Tests.Support;
+
+sealed class SelfLogCollector: IDisposable
+{
+    static readonly AsyncLocal<SelfLogCollector?> Collectors = new();
+
+    static SelfLogCollector()
+    {
+        SelfLog.Enable(m => Collectors.Value?.Messages.Add(m));
+    }
+
+    public SelfLogCollector()
+    {
+        if (Collectors.Value != null)
+            throw new InvalidOperationException("SelfLogCollector is already in use in this task.");
+
+        Collectors.Value = this;
+    }
+
+    public IList<string> Messages { get; } = new List<string>();
+
+    public void Dispose()
+    {
+        Collectors.Value = null;
+    }
+}


### PR DESCRIPTION
Fixes #198 

The construction of a bookmark file normally creates one if it doesn't already exist. This PR follows the behavior of the "write" path by also attempting to create the directory if necessary (`Directory.CreateDirectory()` is idempotent).

Although it can't be exercised currently, this would also prevent a potential startup-time race condition if the shipper were to get started before, or faster than, the file sink.
